### PR TITLE
[IMP] fix/update missing reference

### DIFF
--- a/docs/overview/concepts/integrated_beneficiary_registry.md
+++ b/docs/overview/concepts/integrated_beneficiary_registry.md
@@ -61,4 +61,4 @@ The Integrated Beneficiary Registry is a cornerstone in modern social protection
 ## References
 
 - [SPDCI - Social Protection Information System Interacting with Integrated
-  Beneficiary Registry](https://spdci.org/resources/interoperability-in-action-7-integrated-beneficiary-registry-english-recording/)
+  Beneficiary Registry](https://standards.spdci.org/standards/wip-integrated-beneficiary-registry-v1.0.0/resources/interoperability-in-action-7)


### PR DESCRIPTION
The previous reference is a dead link.

Used [wayback machine](https://web.archive.org/web/20241214123429/https://spdci.org/resources/interoperability-in-action-7-integrated-beneficiary-registry-english-recording/) and saw it used to reference "Interoperability in Action `#7` – Integrated Beneficiary Registry – English Recording". 

Found this page on spdci docs that is potentially the same just re-organized or moved. The page was _Last updated 4 months ago_ as of writing.