### PR TITLE
fix(build): use minimal docs requirements for Python 3.11+ compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,8 @@ distclean:  ## Clean docs build directory, Python virtual environment, and fetch
 
 bin/python:
 	python3 -m venv . || virtualenv --clear --python=python3 .
-	bin/pip install -r requirements_frozen.txt
+	bin/pip install --upgrade pip
+	bin/pip install -r requirements_docs.txt
 
 .PHONY: fetch-odoo
 fetch-odoo:  ## Fetch Odoo sources for documentation build

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -465,6 +465,8 @@ redirects = {
     # Add more redirects as content is migrated
 }
 
+# -- Options for MYST output -------------------------------------------------
+myst_heading_anchors = 3
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -1,0 +1,43 @@
+# Documentation build requirements
+# These are the minimal requirements needed to build OpenSPP documentation
+# with Sphinx. This file excludes Odoo/Plone dependencies that require
+# system libraries (python-ldap, psycopg2, Pillow, etc.)
+
+# Core Sphinx and theme
+Sphinx>=4.0,<8
+sphinx-book-theme>=0.3.3,<2
+sphinx-autobuild>=2021.3.14
+
+# Sphinx extensions
+sphinx-copybutton>=0.5
+sphinx-design>=0.3
+sphinx-notfound-page>=0.8
+sphinx-sitemap>=2.5
+sphinx-togglebutton>=0.3
+sphinx-tabs>=3.2
+sphinxcontrib-httpdomain>=1.8
+sphinxcontrib-httpexample>=1.1
+sphinxcontrib-video>=0.0.1
+sphinxcontrib-mermaid>=0.9
+sphinxcontrib-googleanalytics>=0.4
+sphinxext-opengraph>=0.8
+sphinx-reredirects>=0.1
+
+# MyST parser for Markdown support
+myst-parser>=0.18,<4
+linkify-it-py>=2.0
+
+# Document processing
+docutils>=0.16,<0.22
+Pygments>=2.14
+
+# Required by conf.py
+beautifulsoup4>=4.11
+PyYAML>=6.0
+graphviz>=0.20
+
+# JSX lexer for code highlighting
+jsx-lexer>=2.0
+
+# Less CSS processing
+lesscpy>=0.15


### PR DESCRIPTION
- Add requirements_docs.txt with only Sphinx and documentation dependencies
- Update Makefile to use requirements_docs.txt instead of requirements_frozen.txt
- Change build output directory from _build to build
- Upgrade pip before installing requirements

The frozen requirements included Odoo/Plone packages (python-ldap, psycopg2, Pillow) that require system libraries not available in all environments. This change allows building documentation without those dependencies.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-only changes affecting documentation dependency installation and a small Sphinx config tweak; no runtime or security-sensitive code paths are modified.
> 
> **Overview**
> Improves docs build portability by switching the virtualenv install step from a frozen, full dependency set to a new minimal `requirements_docs.txt` that excludes heavy/system-library packages (e.g., Odoo/Plone-related deps).
> 
> The Makefile now upgrades `pip` before installing docs requirements, and Sphinx config adds `myst_heading_anchors` to generate anchors for Markdown headings.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9521f8584e7e99244ae7edda6fdbb34191598979. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->