### PR TITLE
Fix cards and lines

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -510,7 +510,7 @@ li.module-filtered > a {
 /* Limit Key feature card image size on homepage + align right */
 .sd-card .sd-card-img-top,
 .sd-card img[src*="images/0"] {
-  max-height: 50px;
+  max-height: 80px;
   width: auto;
   object-fit: contain;
   display: block;

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -506,3 +506,32 @@ li.module-filtered > a {
     text-decoration: line-through;
     color: #6c757d;
 }
+
+/* Limit Key feature card image size on homepage + align right */
+.sd-card .sd-card-img-top,
+.sd-card img[src*="images/0"] {
+  max-height: 50px;
+  width: auto;
+  object-fit: contain;
+  display: block;
+  margin-left: 10px;
+  margin-right: auto;
+}
+
+/* Override theme’s !important for Key feature cards only */
+.sd-card.sd-sphinx-override.sd-w-100.sd-shadow-sm.docutils {
+  box-shadow: none !important;
+}
+
+.sd-card,
+.sd-card .sd-card-img-top,
+.sd-card .sd-card-body {
+  border: none !important;
+  box-shadow: none !important;
+}
+
+
+.sd-card.sd-sphinx-override.sd-w-100.sd-shadow-sm.docutils * {
+  border: none !important;
+  box-shadow: none !important;
+}


### PR DESCRIPTION
Fixed Cards and icons in index.md welcome page

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only changes scoped to documentation card components; risk is limited to unintended visual regressions in docs styling.
> 
> **Overview**
> Tweaks the docs theme styling for the homepage “Key feature” cards by **constraining/aligning card images** and **removing card borders/shadows** (overriding theme `!important` where needed).
> 
> No functional/code changes; this is a CSS-only visual adjustment in `docs/_static/custom.css`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ca1039c62934577e59e78034b80776672eeb9830. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->