### PR TITLE
fix(#703): reapply style updates from task #390 for v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -176,3 +176,5 @@ paste_image_to_wsl.sh
 docs/_images/**/*.py
 docs/_images/**/*.sh
 tests/
+
+.cursor/

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -510,7 +510,7 @@ li.module-filtered > a {
 /* Limit Key feature card image size on homepage + align right */
 .sd-card .sd-card-img-top,
 .sd-card img[src*="images/0"] {
-  max-height: 50px;
+  max-height: 80px;
   width: auto;
   object-fit: contain;
   display: block;

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,427 +1,512 @@
 :root {
-  /* Add Font Awesome 5 icon and color for todo */
-  --pst-icon-clipboard-list: '\f46d';
-  --pst-icon-admonition-todo: var(--pst-icon-clipboard-list);
-  --pst-color-admonition-todo: 161, 46, 233;
-  --target-color: #b9ee9e;
-  --codeblock-color: #aad993;
+    /* Add Font Awesome 5 icon and color for todo */
+    --pst-icon-clipboard-list: "\f46d";
+    --pst-icon-admonition-todo: var(--pst-icon-clipboard-list);
+    --pst-color-admonition-todo: 161, 46, 233;
+    --target-color: rgba(50, 100, 200, 0.2);
+    --codeblock-color: rgba(50, 100, 200, 0.15);
+
+    /* OpenSPP Brand Colors */
+    --openspp-primary: #033a51;
+    --openspp-brand: #3264c8;
+}
+
+/* Import Manrope font */
+@import url('https://fonts.googleapis.com/css2?family=Manrope:wght@200..800&display=swap');
+
+/* Global Typography */
+body {
+    font-family: "Manrope", sans-serif;
+    color: #033a51;
+    text-align: left;
+}
+
+::selection {
+    background-color: #3264c8;
+    color: #ffffff;
+}
+
+/* Headers */
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+    font-family: "Manrope", sans-serif;
+    color: #033a51;
+    font-weight: 700; /* Bold headers */
+}
+
+/* Paragraph alignment */
+p {
+    text-align: left;
 }
 
 .visuallyhidden {
-  display: none;
+    display: none;
 }
 
 pre {
-  border-radius: 0;
-  background-color: white;
-  box-shadow: none;
+    border-radius: 0;
+    background-color: white;
+    box-shadow: none;
 }
 
 a,
 a:visited,
 main.bd-content #main-content a,
 main.bd-content #main-content a:visited {
-  color: #2980b9;
+    color: #3264c8; /* Brand color for links */
 }
 
 a:hover,
 main.bd-content #main-content a:hover {
-  color: #1a567e;
-  text-decoration: none;
+    color: #1a4a9c;
+    text-decoration: none;
 }
 
 ul {
-  list-style-type: square;
+    list-style-type: square;
+    text-align: left;
 }
 
-ul li>p {
-  margin-bottom: 0.3rem;
+ol {
+    text-align: left;
 }
 
-ol li>p {
-  margin-bottom: 0.3rem;
+ul li > p {
+    margin-bottom: 0.3rem;
+    text-align: left;
+}
+
+ol li > p {
+    margin-bottom: 0.3rem;
+    text-align: left;
 }
 
 img {
-  margin: 1rem 0;
+    margin: 1rem 0;
+    text-align: left;
 }
 
 figure img,
 img.figure,
 .figure img {
-  box-shadow: 0 6px 24px 0 rgba(153, 153, 153, 0.3);
+    box-shadow: 0 6px 24px 0 rgba(153, 153, 153, 0.3);
+    text-align: left;
 }
 
 .sidebar img.logo {
-  box-shadow: none;
-  width: 200px;
-  margin-bottom: 1rem;
+    box-shadow: none;
+    width: 200px;
+    margin-bottom: 1rem;
+    text-align: left;
 }
 
 img.inline {
-  margin: 0;
-  height: 1em;
+    margin: 0;
+    height: 1em;
+    text-align: left;
 }
 
 span.linenos {
-  padding-right: 1em;
+    padding-right: 1em;
+    text-align: left;
 }
 
 dt:target,
 span.highlighted,
 ul.search li span.highlighted {
-  background-color: var(--target-color);
+    background-color: var(--target-color);
+    text-align: left;
+}
+
+mark,
+.bd-content mark {
+    background-color: var(--target-color);
+    color: #3264c8;
+    padding: 0 0.2em;
 }
 
 .bd-sidebar .nav ul {
-  padding: 0 0 0 1rem;
+    padding: 0 0 0 1rem;
+    text-align: left;
 }
 
-.bd-sidebar .nav .toctree-checkbox~label i {
-  transform: rotate(90deg);
+.bd-sidebar .nav .toctree-checkbox ~ label i {
+    transform: rotate(90deg);
+    text-align: left;
 }
 
-.bd-sidebar .nav .toctree-checkbox:checked~label i {
-  transform: rotate(0deg);
+.bd-sidebar .nav .toctree-checkbox:checked ~ label i {
+    transform: rotate(0deg);
+    text-align: left;
 }
 
 .toctree-wrapper .caption {
-  font-weight: bold;
-  font-size: 1.2em;
-  margin-top: 3rem;
+    font-weight: bold;
+    font-size: 1.2em;
+    margin-top: 3rem;
+    text-align: left;
+    color: #033a51;
+    font-family: "Manrope", sans-serif;
 }
 
 .toctree-wrapper ul {
-  list-style: none;
+    list-style: none;
+    text-align: left;
 }
 
-section:not(#glossary) h1~dl {
-  display: grid;
-  grid-template-columns: max-content auto;
+section:not(#glossary) h1 ~ dl {
+    display: grid;
+    grid-template-columns: max-content auto;
+    text-align: left;
 }
 
-section:not(#glossary) h1~dl dd {
-  margin-bottom: unset !important;
+section:not(#glossary) h1 ~ dl dd {
+    margin-bottom: unset !important;
+    text-align: left;
 }
 
 div.section {
-  margin-bottom: 5rem;
+    margin-bottom: 5rem;
+    text-align: left;
 }
 
 div.section div.section {
-  margin-bottom: 2rem;
+    margin-bottom: 2rem;
+    text-align: left;
 }
 
 div.section div.section div.section {
-  margin-bottom: 2rem;
+    margin-bottom: 2rem;
+    text-align: left;
 }
 
 /* admonitions */
 .admonition {
-  border-radius: 0;
-  border: none;
-  border-left: .2rem solid;
-  border-left-color: rgba(var(--pst-color-admonition-default), 1);
+    border-radius: 0;
+    border: none;
+    border-left: 0.2rem solid;
+    border-left-color: rgba(var(--pst-color-admonition-default), 1);
+    text-align: left;
 }
 
 .admonition .admonition-title {
-  margin-bottom: 1.5rem !important;
+    margin-bottom: 1.5rem !important;
+    text-align: left;
+    font-family: "Manrope", sans-serif;
+    color: #033a51;
+    font-weight: 700;
 }
 
 /* admonition todo */
 .admonition.admonition-todo,
 div.admonition.admonition-todo {
-  border-color: rgba(var(--pst-color-admonition-todo), 1);
+    border-color: rgba(var(--pst-color-admonition-todo), 1);
+    text-align: left;
 }
 
-.admonition.admonition-todo>.admonition-title,
-div.admonition.admonition-todo>.admonition-title {
-  background-color: rgba(var(--pst-color-admonition-todo), .1);
+.admonition.admonition-todo > .admonition-title,
+div.admonition.admonition-todo > .admonition-title {
+    background-color: rgba(var(--pst-color-admonition-todo), 0.1);
+    text-align: left;
 }
 
-.admonition.admonition-todo>.admonition-title::before,
-div.admonition.admonition-todo>.admonition-title::before {
-  color: rgba(var(--pst-color-admonition-todo), 1);
-  content: var(--pst-icon-admonition-todo);
+.admonition.admonition-todo > .admonition-title::before,
+div.admonition.admonition-todo > .admonition-title::before {
+    color: rgba(var(--pst-color-admonition-todo), 1);
+    content: var(--pst-icon-admonition-todo);
+    text-align: left;
 }
 
 .admonition-github-only.admonition {
-  display: none;
+    display: none;
+    text-align: left;
 }
 
 /* admonition margin */
 .admonition.margin ul,
 .admonition.margin ol {
-  padding-left: 1rem;
+    padding-left: 1rem;
+    text-align: left;
 }
 
 .topic {
-  padding: 1.5em 1em .5em 1em;
+    padding: 1.5em 1em 0.5em 1em;
+    text-align: left;
 }
 
 .topic-title {
-  font-weight: bold;
+    font-weight: bold;
+    text-align: left;
+    font-family: "Manrope", sans-serif;
+    color: #033a51;
 }
-
 
 /* Bootstrap */
 .btn-primary {
-  color: #fff;
-  background-color: #2980b9;
-  border-color: #2980b9;
+    color: #fff;
+    background-color: #3264c8; /* Brand color */
+    border-color: #3264c8;
+    text-align: left;
 }
 
 .btn-primary {
-  background-color: #1f86ca;
-  border-color: #2980b9;
+    background-color: #1a4a9c; /* Darker brand color for hover state */
+    border-color: #3264c8;
+    text-align: left;
 }
 
 /* Search */
 
 /* Show search form. It is hidden by default. */
 #search-documentation,
-#search-documentation~form,
-#search-documentation~p {
-  display: block;
+#search-documentation ~ form,
+#search-documentation ~ p {
+    display: block;
 }
 
 #search-form:focus-within #shortcut-page,
 .bd-search:focus-within #shortcut {
-  display: none;
+    display: none;
 }
 
 #shortcut-page.input-group-text {
-  padding-top: 0;
-  padding-bottom: 0;
+    padding-top: 0;
+    padding-bottom: 0;
 }
 
 input#q {
-  border-radius: .25rem 0 0 .25rem;
+    border-radius: 0.25rem 0 0 0.25rem;
 }
 
 .form-control:focus {
-  box-shadow: none;
-  border-width: 2px;
+    box-shadow: none;
+    border-width: 2px;
 }
 
 ul.search {
-  margin-left: 0;
+    margin-left: 0;
 }
 
 p.search-summary {
-  margin: 1em 0 2rem 0;
+    margin: 1em 0 2rem 0;
 }
 
 #search-results ul {
-  list-style-type: none;
-  padding-left: 0;
+    list-style-type: none;
+    padding-left: 0;
 }
 
 #search-results ul li,
 ul.search li {
-  margin-bottom: 2rem;
-  padding: 0;
-  background-image: none;
-  border-bottom: none;
+    margin-bottom: 2rem;
+    padding: 0;
+    background-image: none;
+    border-bottom: none;
 }
 
 #search-results ul li h3 {
-  margin: 0.4rem 0 .5rem;
-  font-size: 1.5rem;
+    margin: 0.4rem 0 0.5rem;
+    font-size: 1.5rem;
 }
 
 #search-results ul li .breadcrumbs {
-  display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
 }
 
 #search-results ul li .breadcrumbs a {
-  font-weight: normal;
+    font-weight: normal;
 }
 
 #search-results ul li .breadcrumbs .lastbreadcrumb {
-  white-space: nowrap;
-  display: inline-block;
-  max-width: 12rem;
-  overflow: hidden;
-  /* "overflow"-Wert darf nicht "visible" sein */
+    white-space: nowrap;
+    display: inline-block;
+    max-width: 12rem;
+    overflow: hidden;
+    /* "overflow"-Wert darf nicht "visible" sein */
 
-  text-overflow: ellipsis;
+    text-overflow: ellipsis;
 }
 
 ul.search li p.context {
-  margin-left: 0;
+    margin-left: 0;
 }
 
 /* Search form sidebar */
 
 .bd-search {
-  font-size: .8rem;
+    font-size: 0.8rem;
 }
 
 .bd-search:focus-within #search-input {
-  border-radius: .25rem;
+    border-radius: 0.25rem;
 }
 
 #shortcut.input-group-text {
-  padding-top: 0;
-  padding-bottom: 0;
+    padding-top: 0;
+    padding-bottom: 0;
 }
 
 .bd-search input,
 .bd-search .input-group-text {
-  font-size: .8rem;
-  padding-left: .5em;
+    font-size: 0.8rem;
+    padding-left: 0.5em;
 }
 
 input#search-input {
-  padding-left: 2.1875rem;
-  border-radius: .25rem 0 0 .25rem;
+    padding-left: 2.1875rem;
+    border-radius: 0.25rem 0 0 0.25rem;
 }
 
 .search-icon {
-  position: absolute;
-  color: #a4a6a7;
-  left: .625rem;
-  z-index: 100;
-  align-self: center;
+    position: absolute;
+    color: #a4a6a7;
+    left: 0.625rem;
+    z-index: 100;
+    align-self: center;
 }
 
 .input-group-text kbd {
-  padding: 0rem 0.4rem;
-  font-size: 135%;
+    padding: 0rem 0.4rem;
+    font-size: 135%;
 }
 
 .pathseparator {
-  padding: 0 0.7rem;
+    padding: 0 0.7rem;
 }
 
 /* header-article */
 div.header-article__label {
-  display: flex;
-  align-items: center;
-  margin: 0 auto 0 1em;
-  font-size: 80%;
-  overflow: hidden;
-  white-space: nowrap;
+    display: flex;
+    align-items: center;
+    margin: 0 auto 0 1em;
+    font-size: 80%;
+    overflow: hidden;
+    white-space: nowrap;
 }
 
 /* submenu */
 .bd-toc {
-  box-shadow: 0 .2rem .5rem rgba(0, 0, 0, .05), 0 0 .0625rem rgba(0, 0, 0, .1);
+    box-shadow:
+        0 0.2rem 0.5rem rgba(0, 0, 0, 0.05),
+        0 0 0.0625rem rgba(0, 0, 0, 0.1);
 }
 
 /* extra sidebar */
 div.sidebar:not(.margin) {
-  width: 40%;
-  float: right;
-  clear: right;
-  margin: .3rem 0 .3rem 0.5em;
-  padding: 2rem 0 1.5rem 1rem !important;
-  background-color: rgba(var(--pst-color-admonition-note), .1);
-  border: none;
-  border-left: 8px rgba(var(--pst-color-admonition-default), 1) solid;
-  border-radius: .2rem;
-  box-shadow: 0 .2rem .5rem rgba(0, 0, 0, .05), 0 0 .0625rem rgba(0, 0, 0, .1);
+    width: 40%;
+    float: right;
+    clear: right;
+    margin: 0.3rem 0 0.3rem 0.5em;
+    padding: 2rem 0 1.5rem 1rem !important;
+    background-color: rgba(var(--pst-color-admonition-note), 0.1);
+    border: none;
+    border-left: 8px rgba(var(--pst-color-admonition-default), 1) solid;
+    border-radius: 0.2rem;
+    box-shadow:
+        0 0.2rem 0.5rem rgba(0, 0, 0, 0.05),
+        0 0 0.0625rem rgba(0, 0, 0, 0.1);
 }
 
 div.sidebar:not(.margin) .figure {
-  margin-top: 0;
-  padding-top: 0;
-  margin-left: 0;
-  padding-left: 0;
+    margin-top: 0;
+    padding-top: 0;
+    margin-left: 0;
+    padding-left: 0;
 }
 
 div.sidebar:not(.margin) img.logo {
-  margin-top: 0;
-  margin-bottom: .3rem;
+    margin-top: 0;
+    margin-bottom: 0.3rem;
 }
 
 div.sidebar:not(.margin) p {
-  margin-bottom: 0;
+    margin-bottom: 0;
 }
 
 div.sidebar:not(.margin) p.sidebar-title {
-  display: none;
+    display: none;
 }
 
 div.sidebar:not(.margin) div.topic {
-  padding: .5em 0;
-  background-color: transparent;
-  border: none;
+    padding: 0.5em 0;
+    background-color: transparent;
+    border: none;
 }
 
 div.sidebar:not(.margin) pre {
-  margin: .5em 0 1.5em 0;
+    margin: 0.5em 0 1.5em 0;
 }
 
 div.sidebar:not(.margin) div[class*="highlight-"] {
-  margin-right: .5em;
+    margin-right: 0.5em;
 }
 
 div.sidebar:not(.margin) .admonition {
-  margin-right: .5em;
-  background-color: #ffffff;
+    margin-right: 0.5em;
+    background-color: #ffffff;
 }
 
-@media (min-width:768px) {
-  div.sidebar:not(.margin) {
-    width: 50%;
-    margin-left: 1.5em;
-    margin-right: -28%;
-  }
+@media (min-width: 768px) {
+    div.sidebar:not(.margin) {
+        width: 50%;
+        margin-left: 1.5em;
+        margin-right: -28%;
+    }
 }
-
 
 main.bd-content #main-content dl.simple dt {
-  margin-top: .8em;
+    margin-top: 0.8em;
 }
 
 main.bd-content #main-content dl.simple dt:nth-of-type(1) {
-  margin-top: 0;
+    margin-top: 0;
 }
 
 main.bd-content #main-content dl.simple dd {
-  margin-top: .8em;
+    margin-top: 0.8em;
 }
 
-main.bd-content #main-content dl.simple dt+dd {
-  margin-top: 0;
+main.bd-content #main-content dl.simple dt + dd {
+    margin-top: 0;
 }
 
 .prev-next-bottom {
-  margin: 20px 0 30px 0;
+    margin: 20px 0 30px 0;
 }
 
 .prev-next-bottom a.left-prev,
 .prev-next-bottom a.right-next {
-  padding: 5px 10px;
-  border: 1px solid rgba(0, 0, 0, .2);
-  max-width: 45%;
-  overflow-x: hidden;
-  color: rgba(0, 0, 0, .65);
-  border-radius: 10px;
+    padding: 5px 10px;
+    border: 1px solid rgba(0, 0, 0, 0.2);
+    max-width: 45%;
+    overflow-x: hidden;
+    color: rgba(0, 0, 0, 0.65);
+    border-radius: 10px;
 }
 
 /* Local navigation */
 li.nav-item.toc-entry {
-  line-height: 1.25em;
-  margin-bottom: 0.25em;
+    line-height: 1.25em;
+    margin-bottom: 0.25em;
 }
 
 span.guilabel,
 span.menuselection {
-  border: none;
-  background: #e7f2fa;
-  border-radius: 4px;
-  padding: 4px 5px;
-  font-size: 90%;
-  font-weight: bold;
-  font-style: italic;
-  white-space: nowrap;
+    border: none;
+    background: #e7f2fa;
+    border-radius: 4px;
+    padding: 4px 5px;
+    font-size: 90%;
+    font-weight: bold;
+    font-style: italic;
+    white-space: nowrap;
 }
-
 
 /*
  * extensions
@@ -429,59 +514,103 @@ span.menuselection {
 
 /* definitions */
 dl.py.function {
-  margin-bottom: 5rem;
+    margin-bottom: 5rem;
 }
 
-dl.py.function>dt {
-  background-color: var(--codeblock-color);
-  padding: 4px 5px;
+/* Quick Start Banners */
+#quick-start > p {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 1.5rem;
 }
 
-dl.py.function>dt:target {
-  background-color: var(--target-color);
+@media (min-width: 700px) {
+    #quick-start > p {
+        display: grid;
+        grid-template-columns: repeat(2, 1fr);
+        gap: 1.5rem;
+    }
 }
 
-dl.field-list>dt {
-  padding-left: 0;
+/* Resources & Community Section */
+#main-content .section .grid {
+    margin-top: 2rem;
+}
+
+#main-content .section .grid .grid-item ul {
+    list-style: none;
+    padding-left: 0;
+}
+
+#main-content .section .grid .grid-item ul li {
+    margin-bottom: 0.5rem;
+}
+
+#main-content .section .grid .grid-item ul li a {
+    color: #3264c8;
+    text-decoration: none;
+}
+
+#main-content .section .grid .grid-item ul li a:hover {
+    text-decoration: underline;
+}
+
+dl.py.function > dt {
+    background-color: var(--codeblock-color);
+    padding: 4px 5px;
+}
+
+dl.py.function > dt:target {
+    background-color: var(--target-color);
+}
+
+dl.field-list > dt {
+    padding-left: 0;
 }
 
 /* code blocks */
 div.viewcode-block:target {
-  padding: 10px 10px;
-  background-color: var(--codeblock-color);
-  border-top: 1px solid var(--codeblock-color);
-  border-bottom: 1px solid var(--codeblock-color);
+    padding: 10px 10px;
+    background-color: var(--codeblock-color);
+    border-top: 1px solid var(--codeblock-color);
+    border-bottom: 1px solid var(--codeblock-color);
 }
 
 /* Fix paragraphs in list items. */
-#main-content ol > li > p:nth-child(n+2),
-#main-content ul > li > p:nth-child(n+2) {
-  margin-top: 1em;
+#main-content ol > li > p:nth-child(n + 2),
+#main-content ul > li > p:nth-child(n + 2) {
+    margin-top: 1em;
 }
 
 @media (min-width: 768px) {
-  div.navbar-brand-box {
-      padding-top:0
-  }
+    div.navbar-brand-box {
+        padding-top: 0;
+    }
 }
 
-dl.py > dd, dl.js > dd, dl.o-definition-list > dd {
-  margin-top: -0.075rem;
-  margin-left: 0;
-  padding-left: 1rem;
-  padding-top: 0.5rem;
-  border-left: 3px solid #F2F2F2;
+dl.py > dd,
+dl.js > dd,
+dl.o-definition-list > dd {
+    margin-top: -0.075rem;
+    margin-left: 0;
+    padding-left: 1rem;
+    padding-top: 0.5rem;
+    border-left: 3px solid #f2f2f2;
 }
 
-.o_code, .sig [class^="sig-"] {
-  display: inline-block;
-  overflow-wrap: anywhere;
-  background: #F2F2F2;
-  font-size: 0.875rem;
-  font-family: 'Consolas', 'Menlo', 'DejaVu Sans Mono', 'Bitstream Vera Sans Mono', monospace;
-  font-weight: inherit;
-  /* color: inherit; */
+.o_code,
+.sig [class^="sig-"] {
+    display: inline-block;
+    overflow-wrap: anywhere;
+    background: #f2f2f2;
+    font-size: 0.875rem;
+    font-family:
+        "Consolas", "Menlo", "DejaVu Sans Mono", "Bitstream Vera Sans Mono",
+        monospace;
+    font-weight: inherit;
+    /* color: inherit; */
 }
+
 /* Module filter on search page */
 #search-module-filter {
     border-top: 1px solid #e0e0e0;
@@ -507,31 +636,50 @@ li.module-filtered > a {
     color: #6c757d;
 }
 
-/* Limit Key feature card image size on homepage + align right */
-.sd-card .sd-card-img-top,
-.sd-card img[src*="images/0"] {
-  max-height: 80px;
-  width: auto;
-  object-fit: contain;
-  display: block;
-  margin-left: 10px;
-  margin-right: auto;
+/* Key features section */
+#key-features .sd-card {
+    border: none !important;
+    box-shadow: none !important;
 }
 
-/* Override theme’s !important for Key feature cards only */
-.sd-card.sd-sphinx-override.sd-w-100.sd-shadow-sm.docutils {
-  box-shadow: none !important;
+#key-features .sd-card-body {
+    display: flex;
+    flex-direction: column;
+    text-align: left;
+    padding: 0;
 }
 
-.sd-card,
-.sd-card .sd-card-img-top,
-.sd-card .sd-card-body {
-  border: none !important;
-  box-shadow: none !important;
+#key-features .sd-card-header {
+    padding: 0;
+    border-bottom: none;
 }
 
+#key-features .sd-card-header strong {
+    color: var(--openspp-brand);
+}
 
-.sd-card.sd-sphinx-override.sd-w-100.sd-shadow-sm.docutils * {
-  border: none !important;
-  box-shadow: none !important;
+#key-features .sd-card-body .sd-card-text {
+    font-size: 1rem;
+    color: var(--openspp-primary);
+}
+
+#key-features .sd-card a {
+    text-decoration: none;
+}
+
+#key-features .sd-card-img-top {
+    max-height: 50px;
+    width: 50px;
+    margin-bottom: 1rem;
+    margin-left: 0;
+}
+
+#key-features .sd-card-header .sd-card-text {
+    font-size: 1.2rem;
+    font-weight: bold;
+    color: #033a51;
+}
+
+#site-navigation h1.site-logo {
+    text-align: left;
 }

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -637,10 +637,6 @@ li.module-filtered > a {
 }
 
 /* Key features section */
-#key-features .sd-card {
-    border: none !important;
-    box-shadow: none !important;
-}
 
 #key-features .sd-card-body {
     display: flex;
@@ -667,11 +663,33 @@ li.module-filtered > a {
     text-decoration: none;
 }
 
-#key-features .sd-card-img-top {
-    max-height: 50px;
-    width: 50px;
-    margin-bottom: 1rem;
-    margin-left: 0;
+/* Limit Key feature card image size on homepage + align right */
+.sd-card .sd-card-img-top,
+.sd-card img[src*="images/0"] {
+  max-height: 80px;
+  width: auto;
+  object-fit: contain;
+  display: block;
+  margin-left: 10px;
+  margin-right: auto;
+}
+
+/* Override theme’s !important for Key feature cards only */
+.sd-card.sd-sphinx-override.sd-w-100.sd-shadow-sm.docutils {
+  box-shadow: none !important;
+}
+
+.sd-card,
+.sd-card .sd-card-img-top,
+.sd-card .sd-card-body {
+  border: none !important;
+  box-shadow: none !important;
+}
+
+
+.sd-card.sd-sphinx-override.sd-w-100.sd-shadow-sm.docutils * {
+  border: none !important;
+  box-shadow: none !important;
 }
 
 #key-features .sd-card-header .sd-card-text {

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -506,3 +506,32 @@ li.module-filtered > a {
     text-decoration: line-through;
     color: #6c757d;
 }
+
+/* Limit Key feature card image size on homepage + align right */
+.sd-card .sd-card-img-top,
+.sd-card img[src*="images/0"] {
+  max-height: 50px;
+  width: auto;
+  object-fit: contain;
+  display: block;
+  margin-left: 10px;
+  margin-right: auto;
+}
+
+/* Override theme’s !important for Key feature cards only */
+.sd-card.sd-sphinx-override.sd-w-100.sd-shadow-sm.docutils {
+  box-shadow: none !important;
+}
+
+.sd-card,
+.sd-card .sd-card-img-top,
+.sd-card .sd-card-body {
+  border: none !important;
+  box-shadow: none !important;
+}
+
+
+.sd-card.sd-sphinx-override.sd-w-100.sd-shadow-sm.docutils * {
+  border: none !important;
+  box-shadow: none !important;
+}

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -10,10 +10,10 @@
 <script src="{{ pathto('_static/review_status_simple.js', 1) }}"></script>
 -->
 
-<script src="https://cdn.jsdelivr.net/npm/less@4.1.1" ></script>
+<script src="https://cdn.jsdelivr.net/npm/less@4.1.1" integrity="sha384-vJ1NXwwlC62VkTLRHyzdAfyL4rQ8Z478DeHgamh37YzGJh3T6j223FC2yMRVriLl" crossorigin="anonymous"></script>
 
 <!-- Mermaid Support -->
-<script src="https://cdn.jsdelivr.net/npm/mermaid@10.6.1/dist/mermaid.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/mermaid@10.6.1/dist/mermaid.min.js" integrity="sha384-+NGfjU8KzpDLXRHduEqW+ZiJr2rIg+cidUVk7B51R5xK7cHwMKQfrdFwGdrq1Bcz" crossorigin="anonymous"></script>
 <script>
 document.addEventListener('DOMContentLoaded', function() {
     mermaid.initialize({

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -1,6 +1,33 @@
 {% extends "sphinx_book_theme/layout.html" %}
 {%- block extrahead %}
 {{ super() }}
+{%- if is_preview %}
+<!-- Prevent search engines from indexing preview documentation -->
+<meta name="robots" content="noindex,nofollow,noarchive">
+{%- endif %}
+<!-- Review Status System - DISABLED
+<link rel="stylesheet" href="{{ pathto('_static/review_status.css', 1) }}" type="text/css" />
+<script src="{{ pathto('_static/review_status_simple.js', 1) }}"></script>
+-->
+
+<script src="https://cdn.jsdelivr.net/npm/less@4.1.1" ></script>
+
+<!-- Mermaid Support -->
+<script src="https://cdn.jsdelivr.net/npm/mermaid@10.6.1/dist/mermaid.min.js"></script>
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    mermaid.initialize({
+        startOnLoad: true,
+        theme: 'default',
+        themeVariables: {
+            primaryColor: '#0066cc',
+            primaryTextColor: '#000000',
+            primaryBorderColor: '#0066cc'
+        }
+    });
+});
+</script>
+
 <!-- Matomo Tag Manager -->
 <!-- End Matomo Tag Manager -->
 {% endblock %}

--- a/docs/_templates/page.html
+++ b/docs/_templates/page.html
@@ -4,15 +4,23 @@
 <title>{{ title|striptags|e }}{%- for parent in parents %} – {{ parent.title }}{%- endfor %}{{ titlesuffix }}</title>
 {%- endblock %}
 
+{%- block scripts %}
+{{ super() }}
+{%- endblock %}
+
 
 {% block footer %}
+{{ super() }}
     <script type="text/javascript">
         $(document).ready(function() {
             // Hide empty sub menu.
-            if ($.trim($(".sticky-top .bd-toc").html()) === "") {
-                $(".sticky-top .bd-toc").css("visibility", "hidden");
-            }
-        });
+            var lists = $("div.toctree-wrapper ul");
+            $.each(lists, function(index, list) {
+                if($(list).find("li").length == 0) {
+                    $(list).prev().hide();
+                    $(list).hide();
+                }
+            });
+        })
     </script>
-
 {% endblock %}

--- a/docs/_templates/search.html
+++ b/docs/_templates/search.html
@@ -15,7 +15,6 @@
 {% endblock %}
 {%- block scripts %}
   {{ super() }}
-  <script src="{{ pathto('_static/search-utils.js', 1) }}"></script>
   <script src="{{ pathto('_static/searchtools.js', 1) }}"></script>
   <script src="{{ pathto('_static/language_data.js', 1) }}"></script>
 {%- endblock %}
@@ -76,12 +75,27 @@
         </div>
       </div>
 
-      <div id="search-module-filter" class="form row mb-2">
-        <label class="col-12 mb-2"><strong>Filter by module</strong></label>
-        <div class="col-12">
-          <div id="search-module-filter-options" class="d-flex flex-wrap gap-3">
-            <!-- Module checkboxes will be inserted here by JavaScript -->
+      <div class="form row mb-2">
+        <label for="doc_section" class="col sr-only">Filter by section</label>
+        <div class="col">
+          <div class="form-check">
+            <input class="form-check-input" type="radio" name="doc_section" id="doc_section_all" value="all" checked>
+            <label class="form-check-label" for="doc_section_all">
+              All Documentation
+            </label>
           </div>
+          {% for id, title in
+            [
+              ["technical_reference","Technical Reference"],
+              ["user_guide","User Guide"],
+            ] %}
+            <div class="form-check">
+              <input class="form-check-input" type="radio" name="doc_section" id="doc_section_{{id}}" value="{{id}}">
+              <label class="form-check-label" for="doc_section_{{id}}">
+                {{title}}
+              </label>
+            </div>
+          {% endfor %}
         </div>
       </div>
 

--- a/docs/_templates/sections/header-article.html
+++ b/docs/_templates/sections/header-article.html
@@ -1,0 +1,35 @@
+{# To trigger whether the TOC and its button show up #}
+{% set page_toc = generate_toc_html() %}
+{% from "../macros/buttons.html" import render_funcs, render_label_input_button with context %}
+
+<div class="col py-1 d-flex header-article-main">
+    <div class="header-article__left">
+        {% if theme_single_page != True %}
+        {{ render_label_input_button(for_input="__navigation", tooltip="Toggle navigation", icon="fas fa-bars", tooltip_placement="right") }}
+        {% endif %}
+    </div>
+    <div class="header-article__label">
+        <span>{{ title|striptags|e }}{%- for parent in parents[:1] %} – {{ parent.title }}{%- endfor %}</span>
+    </div>
+    <div class="header-article__right">
+        {%- for button in header_buttons -%}
+        {{ render_funcs[button.pop("type")](**button) }}
+        {%- endfor -%}
+
+        {% if page_toc -%}
+        {{ render_label_input_button("__page-toc", icon="fas fa-list", label="page-toc") }}
+        {%- endif %}
+    </div>
+</div>
+
+<!-- Table of contents -->
+<div class="col-md-3 bd-toc show noprint">
+    {%- if page_toc | length >= 1 %}
+    <div class="tocsection onthispage pt-5 pb-3">
+        <i class="fas fa-list"></i> {{ translate(theme_toc_title) }}
+    </div>
+    <nav id="bd-toc-nav" aria-label="Page">
+        {{ page_toc }}
+    </nav>
+    {%- endif %}
+</div>

--- a/docs/_templates/sections/sidebar.html
+++ b/docs/_templates/sections/sidebar.html
@@ -1,0 +1,3 @@
+{%- for sidebartemplate in sidebars %}
+{%- include sidebartemplate %}
+{%- endfor %}

--- a/docs/_templates/sidebar-logo.html
+++ b/docs/_templates/sidebar-logo.html
@@ -1,1 +1,0 @@
-{# Empty placeholder - logo is handled by theme #}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -145,9 +145,9 @@ year = str(now.year)
 # built documents.
 #
 # The short X.Y version.
-version = "1.1"
+version = "2.0"
 # The full version, including alpha/beta/rc tags.
-release = "1.1"
+release = "2.0"
 
 # -- General configuration ----------------------------------------------------
 


### PR DESCRIPTION
<img width="1860" height="914" alt="image" src="https://github.com/user-attachments/assets/00bd9447-2ca0-4bbc-bea8-83693bd2d018" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Primarily documentation theming/template changes, but it alters global asset loading (CDN Mermaid/Less) and search/filter UI wiring, which could break doc rendering or search behavior if the JS/CSS expectations don’t match the new templates.
> 
> **Overview**
> Reapplies and expands the v2 documentation styling: introduces OpenSPP brand colors, Manrope typography, updated link/button/admonition styling, and new homepage-specific layouts (Quick Start, Resources/Community grids, Key Features cards) in `custom.css`.
> 
> Updates Sphinx templates to add **preview no-indexing** (`is_preview` robots meta), load external `less` and **Mermaid** scripts + initialization in `layout.html`, and adjusts `page.html` footer JS to hide empty toctree sections.
> 
> Changes the search UI from the prior module checkbox filter to a **section radio filter** (Technical Reference/User Guide) and removes the `search-utils.js` include from `search.html`; adds new `sections/header-article.html` and `sections/sidebar.html` overrides and drops the `sidebar-logo.html` placeholder. Also bumps docs `version`/`release` to `2.0` and updates `.gitignore` to track `tests/` and ignore `.cursor/`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cb817327a87f49be6b703f9add5423994905d059. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->