### PR TITLE
feat(docs): add version switcher for multi-version documentation

### DIFF
--- a/docs/_static/version_switcher.js
+++ b/docs/_static/version_switcher.js
@@ -1,0 +1,60 @@
+// Custom version switcher for sphinx-book-theme 0.3.3
+document.addEventListener('DOMContentLoaded', function() {
+    // Fetch the switcher.json
+    fetch('/_static/switcher.json')
+        .then(response => response.json())
+        .then(versions => {
+            const currentVer = getCurrentVersion();
+
+            // Create switcher HTML
+            const switcherHtml = `
+                <div class="version-switcher" style="padding: 0.5em;">
+                    <select id="version-select" style="padding: 0.25em; border-radius: 4px; width: 100%;">
+                        ${versions.map(v =>
+                            `<option value="${v.url}" ${v.version === currentVer ? 'selected' : ''}>
+                                ${v.name}
+                            </option>`
+                        ).join('')}
+                    </select>
+                </div>
+            `;
+
+            // Insert into navbar
+            const navbar = document.querySelector('.openspporglink');
+            if (navbar && navbar.parentElement) {
+                navbar.parentElement.insertAdjacentHTML('afterbegin', switcherHtml);
+
+                // Handle version change
+                document.getElementById('version-select').addEventListener('change', function(e) {
+                    const newUrl = e.target.value;
+                    // Get current page path, removing any version prefix
+                    let currentPath = window.location.pathname;
+
+                    // Remove version prefixes like /v1.1/, /v1.3/, /previews/branch/
+                    currentPath = currentPath.replace(/^\/previews\/[^\/]+\//, '/');
+                    currentPath = currentPath.replace(/^\/v[0-9.]+\//, '/');
+                    // Remove leading slash since newUrl already has trailing slash
+                    currentPath = currentPath.replace(/^\/+/, '');
+
+                    // Navigate to same page in new version
+                    window.location.href = newUrl + currentPath;
+                });
+            }
+        })
+        .catch(err => console.log('Version switcher not available:', err));
+});
+
+function getCurrentVersion() {
+    // First check URL for version prefix like /v1.1/ or /v1.3/
+    const urlMatch = window.location.pathname.match(/^\/v([0-9.]+)\//);
+    if (urlMatch) {
+        return urlMatch[1];
+    }
+
+    // Otherwise extract version from page title (e.g., "OpenSPP Documentation v1.1")
+    const title = document.querySelector('title');
+    if (title && title.textContent.includes(' v')) {
+        return title.textContent.split(' v')[1].split(' ')[0];
+    }
+    return 'stable';
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -510,6 +510,11 @@ html_theme_options = {
     """,
 }
 
+# Custom version switcher JS
+html_js_files = [
+    'version_switcher.js',
+]
+
 googleanalytics_id = 'G-RS4T4ZPG52'
 
 # The name for this set of Sphinx documents.  If None, it defaults to


### PR DESCRIPTION
## Summary

Add a custom version switcher dropdown to allow users to navigate between different documentation versions (e.g., v2.0, v1.3).

## Why Custom Implementation?

The built-in version switcher in `pydata-sphinx-theme` requires version 0.9+ and specific navbar configurations. Since this project uses `sphinx-book-theme 0.3.3` (which depends on `pydata-sphinx-theme 0.8.x`), we need a custom JavaScript-based solution that works with these older theme versions.

## Changes

### New Files
- **`docs/_static/version_switcher.js`** - Custom JavaScript that:
  - Fetches `switcher.json` to get available versions
  - Creates a dropdown selector in the sidebar
  - Handles version switching while preserving the current page path
  - Correctly strips version prefixes (e.g., `/v1.3/`, `/previews/branch/`) when navigating

- **`docs/_static/switcher.json`** - Configuration file listing available versions with URLs

### Modified Files
- **`docs/conf.py`**:
  - Updated `version` and `release` to `"2.0"`
  - Added `html_js_files` to include the version switcher script

## How It Works

1. On page load, `version_switcher.js` fetches `switcher.json`
2. Creates a dropdown in the sidebar (inserted before the OpenSPP.org link)
3. Detects current version from URL path (e.g., `/v1.3/`) or falls back to page title
4. When user selects a different version, navigates to the same page in that version

## Deployment Requirements

For versioned documentation to work in production, the CI/CD workflow needs updates:

```yaml
# Example for peaceiris/actions-gh-pages
- uses: peaceiris/actions-gh-pages@v3
  with:
    destination_dir: v2.0  # or root for latest
    keep_files: true       # preserve other versions
```

## Before Production

Update `switcher.json` with production URLs:
```json
[
    {
        "name": "2.0 (latest)",
        "version": "2.0",
        "url": "https://docs.openspp.org/"
    },
    {
        "name": "1.3",
        "version": "1.3",
        "url": "https://docs.openspp.org/v1.3/"
    }
]
```

## Testing Done

- ✅ Tested locally with git worktree to simulate v2.0 and v1.3 versions
- ✅ Version switcher dropdown appears in sidebar
- ✅ Switching versions preserves current page path
- ✅ URL version prefixes are correctly stripped to avoid stacking (e.g., `/v1.3/v1.1/`)
- ✅ Works with sphinx-book-theme 0.3.3

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Low-touch docs-only change, but it modifies `html_js_files` configuration and could unintentionally override/replace other required JS includes depending on existing config structure.
> 
> **Overview**
> Adds a custom JS-based version switcher to the docs UI by fetching `/_static/switcher.json`, rendering a version dropdown, and redirecting to the same page path across versions while stripping existing `/vX.Y/` and `/previews/<branch>/` prefixes.
> 
> Updates `docs/conf.py` to include `version_switcher.js` via `html_js_files`, enabling the switcher to load on all generated HTML pages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f99c342448b63694d0888d296f72229bd8ad6eac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->