### PR TITLE
Update README: fix links, build note, license attribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,18 +5,21 @@
 OpenSPP is an open-source project that aims to streamline the management of social protection programs. It can be used on its own or in conjunction with other services.
 
 
-## OpenSPP
+Browse the published documentation at **https://docs.openspp.org/**.
 
-Browse the OpenSPP Documentation at https://docs.openspp.org/.
+Note: the latest documentation may not yet be merged to this [main](https://github.com/OpenSPP/documentation/tree/main) repository.
 
-Active development on the OpenSPP Documentation takes place on the branch [`main`](https://github.com/openspp/documentation/).
+## Building the documentation
+
+Python 3.11 is required to build the documentation. If you are using pyenv, create a `.python-version` to set the version before running any `make` commands.
+After installing library dependencies - see [docs/contributing/setup-build.md](docs/contributing/setup-build.md) for details - build the documentation using `make html` or `make livehtml`.
 
 ## Contribute
 
-- [Contributing to OpenSPP Documentation](https://docs.openspp.org/contributing/index.html)
-- [Issue Tracker](https://github.com/openspp/documentation/issues)
-- [Source Code](https://github.com/openspp/documentation)
+- [How to contribute to the project](https://docs.openspp.org/community_and_support/how_to_contribute_to_the_project.html) — code, docs, and issues
+- [Issue tracker](https://github.com/OpenSPP/documentation/issues)
+- [Source code](https://github.com/OpenSPP/documentation)
 
 ## License
 
-The project is licensed under the [Creative Commons Attribution 4.0 International License](https://creativecommons.org/licenses/by/4.0/) by [Newlogic](https://newlogic.com).
+The documentation is licensed under the [Creative Commons Attribution 4.0 International License (CC BY 4.0)](https://creativecommons.org/licenses/by/4.0/). OpenSPP and this documentation are maintained by the OpenSPP community and ACN (Association pour la Coopération Numérique), with contributions from others.


### PR DESCRIPTION
Update readme file only in main 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> README-only documentation edits (links/text/build notes) with no runtime or security impact.
> 
> **Overview**
> Updates `README.md` to point readers to the published docs site and adds a note that the newest docs may not be merged into this repo’s `main` branch yet.
> 
> Adds a **Building the documentation** section (Python 3.11 requirement, pyenv note, and `make html`/`make livehtml` steps) and refreshes contribution links/URLs. Updates the license blurb to clarify CC BY 4.0 attribution and community/ACN maintenance.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fddb674baa0b702e6a75df62abbf8579c1957bd1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->