### PR TITLE
Update Docker installation instructions

### DIFF
--- a/docs/get_started/installation/docker.md
+++ b/docs/get_started/installation/docker.md
@@ -46,7 +46,7 @@ git --version             # Expected: 2.30+
 
 ```shell
 # Clone the repository
-git clone https://github.com/OpenSPP/openspp-modules-v2.git
+git clone https://github.com/OpenSPP/OpenSPP2.git
 cd openspp-modules-v2
 
 # Start OpenSPP


### PR DESCRIPTION
Update docker installation link

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that updates a GitHub clone URL; no runtime or behavioral impact.
> 
> **Overview**
> Updates the Docker quick-start docs to clone from the `OpenSPP/OpenSPP2` repository instead of the old `openspp-modules-v2` URL.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a7faccc1bd6dff8e5d92937358ca61af6ad6de45. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->