### PR TITLE
fix: wrong container name in docker installation

### DIFF
--- a/docs/get_started/installation/docker.md
+++ b/docs/get_started/installation/docker.md
@@ -64,6 +64,15 @@ docker compose --profile ui logs -f openspp
 ```
 
 :::{tip}
+If port 8069 is already in use, Docker may assign a different port.
+Find the assigned port by running:
+
+```shell
+docker compose --profile ui port openspp 8069
+```
+:::
+
+:::{tip}
 Add `--build` to the `up` command to force a rebuild when code or dependencies have changed:
 `docker compose --profile ui up -d --build`
 :::


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only changes; the main risk is users following updated commands that must match the actual Compose service names.
> 
> **Overview**
> Fixes the Docker installation guide to match the current Compose setup by switching all commands and references from the old `odoo` container / `openspp-modules-v2` directory to `openspp` / `OpenSPP2` (logs, restart/exec, port lookup, troubleshooting, and restore steps).
> 
> Improves readability and troubleshooting by converting inline comments into Sphinx admonitions (`note`/`tip`/`warning`), adding guidance for port conflicts, and clarifying that the Docker setup is for evaluation/development only.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ea42aa9dbfa2693b4ebb46cbb5115e7b1e869dc7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->