### PR TITLE
docs(modules): regenerate module reference for all 110 modules

### DIFF
--- a/docs/reference/modules/index.md
+++ b/docs/reference/modules/index.md
@@ -6,7 +6,7 @@ openspp:
 
 # Modules Reference
 
-This section provides comprehensive documentation for all OpenSPP V2 modules in **Stable** status. These modules have been tested and are production-ready.
+This section provides comprehensive documentation for all OpenSPP V2 modules.
 
 ## Module Categories
 
@@ -14,186 +14,311 @@ This section provides comprehensive documentation for all OpenSPP V2 modules in 
 
 Foundation modules that provide essential platform functionality.
 
-| Module                              | Summary                                                                                                                                                                                                                              |
-| ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| [Area Management](spp_area)         | Establishes direct associations between registrants, beneficiary groups, and their corresponding geographical administrative areas. It validates registrant-area linkages against official area types, ensuring data integrity.     |
-| [Base (Common)](spp_base_common)    | The base module that provides the main menu, generic configuration, user role management base module, area management base module, and hiding of non-OpenSPP menus. All implementation-specific base modules depend on this module. |
-| [Base Settings](spp_base_setting)   | Provides fundamental configurations for country implementations, establishing core organizational structures such as Country Offices. It also enables tailored user interface adaptations and streamlines user management.          |
-| [Programs](spp_programs)            | Manage cash and in-kind entitlements, integrate with inventory, and enhance program management features for comprehensive social protection and agricultural support.                                                               |
-| [Registry](spp_registry)            | Consolidated registry management for individuals, groups, and membership.                                                                                                                                                           |
-| [Security](spp_security)            | Central security definitions for OpenSPP modules.                                                                                                                                                                                   |
+| Module | Summary |
+| --- | --- |
+| [Area Management](spp_area) | Establishes associations between registrants and geographical administrative areas with validation and hierarchy support. |
+| [Base (Common)](spp_base_common) | Main menu, generic configuration, user role management base, area management base, and non-OpenSPP menu hiding. |
+| [Base Settings](spp_base_setting) | Fundamental configurations for country implementations, Country Offices, and user management. |
+| [GIS](spp_gis) | GIS core with area geo fields, importer extensions, layers, and spatial queries. |
+| [Programs](spp_programs) | Manage cash and in-kind entitlements, integrate with inventory, and program management for social protection. |
+| [Registry](spp_registry) | Consolidated registry management for individuals, groups, and membership. |
+| [Security](spp_security) | Central security definitions for OpenSPP modules. |
+| [Storage Backend](spp_storage_backend) | Pluggable storage backend configuration (Odoo, S3, Azure, Filesystem). |
 
 ### API V2 Modules
 
 RESTful API modules built on FastAPI for external system integration.
 
-| Module                                             | Summary                                                        |
-| -------------------------------------------------- | -------------------------------------------------------------- |
-| [API V2](spp_api_v2)                               | Core API V2 module providing FastAPI-based RESTful endpoints.  |
-| [API V2 - Cycles](spp_api_v2_cycles)               | API endpoints for program cycle management.                    |
-| [API V2 - Data](spp_api_v2_data)                   | API endpoints for data export and reporting.                   |
-| [API V2 - Entitlements](spp_api_v2_entitlements)   | API endpoints for entitlement management.                      |
-| [API V2 - Products](spp_api_v2_products)           | API endpoints for product catalog management.                  |
-| [API V2 - Service Points](spp_api_v2_service_points) | API endpoints for service point management.                  |
-| [API V2 - Vocabulary](spp_api_v2_vocabulary)       | API endpoints for vocabulary/lookup data.                      |
+| Module | Summary |
+| --- | --- |
+| [API V2](spp_api_v2) | Core API V2 module providing FastAPI-based RESTful endpoints. |
+| [API V2 - Change Request](spp_api_v2_change_request) | REST API endpoints for Change Request V2. |
+| [API V2 - Cycles](spp_api_v2_cycles) | API endpoints for program cycle management. |
+| [API V2 - Data](spp_api_v2_data) | API endpoints for variable data push/pull. |
+| [API V2 - Entitlements](spp_api_v2_entitlements) | API endpoints for entitlement management. |
+| [API V2 - GIS](spp_api_v2_gis) | OGC API - Features compliant GIS endpoints for QGIS and GovStack. |
+| [API V2 - Products](spp_api_v2_products) | API endpoints for product catalog management. |
+| [API V2 - Service Points](spp_api_v2_service_points) | API endpoints for service point management. |
+| [API V2 - Simulation](spp_api_v2_simulation) | REST API for simulation scenario management. |
+| [API V2 - Vocabulary](spp_api_v2_vocabulary) | API endpoints for vocabulary/lookup data. |
+| [OAuth](spp_oauth) | OAuth 2.0 authentication framework for API security. |
 
-### Studio Modules
+### Case Management Modules
 
-No-code configuration tools for implementers.
+Modules for individual case tracking and management.
 
-| Module                                               | Summary                                                                                                                                                         |
-| ---------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [Custom Fields](spp_custom_field)                    | Enables administrators to define and add custom data fields directly to registrant profiles, tailoring data collection for specific social protection programs. |
-| [Studio](spp_studio)                                 | No-code customization interface for OpenSPP.                                                                                                                    |
-| [Studio - Change Requests](spp_studio_change_requests) | No-code change request type builder.                                                                                                                          |
-| [Studio - Events](spp_studio_events)                 | No-code event type designer for data collection.                                                                                                                |
-
-### Change Request Modules
-
-Workflow modules for managing data change requests.
-
-| Module                                               | Summary                                                                                                       |
-| ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
-| [Change Request V2](spp_change_request_v2)           | Configuration-driven change request system with UX improvements, conflict detection and duplicate prevention. |
-| [CR Types - Advanced](spp_cr_types_advanced)         | Advanced change request types with custom Python strategies for membership and lifecycle operations.          |
-| [CR Types - Base](spp_cr_types_base)                 | Basic change request types with field mapping strategy.                                                       |
+| Module | Summary |
+| --- | --- |
+| [Case Management Base](spp_case_base) | Core case management with configurable workflow stages and intervention plans. |
+| [Case: CEL Rules](spp_case_cel) | CEL-based triage and assignment rules for case management. |
+| [Case: Demo Data](spp_case_demo) | Demo data generator for Case Management. |
+| [Case: Entitlements](spp_case_entitlements) | Links cases to program entitlements for relationship tracking. |
+| [Case: Graduation](spp_case_graduation) | Link graduation assessments to cases for exit management. |
+| [Case: Programs](spp_case_programs) | Links cases to programs with compliance tracking. |
+| [Case: Registry](spp_case_registry) | Links cases to registrants with area auto-population. |
+| [Case: Sessions](spp_case_session) | Link sessions and training attendance to cases. |
 
 ### CEL Modules
 
 Common Expression Language modules for rule-based logic.
 
-| Module                                    | Summary                                                                         |
-| ----------------------------------------- | ------------------------------------------------------------------------------- |
-| [CEL Domain Query Builder](spp_cel_domain)| Write simple CEL-like expressions to filter records (OpenSPP/OpenG2P friendly). |
-| [CEL Expression Widget](spp_cel_widget)   | Reusable CEL expression editor with syntax highlighting and autocomplete.       |
+| Module | Summary |
+| --- | --- |
+| [CEL Domain Query Builder](spp_cel_domain) | Write simple CEL-like expressions to filter records. |
+| [CEL Event Data](spp_cel_event) | Integrate event data with CEL expressions for eligibility rules. |
+| [CEL Expression Widget](spp_cel_widget) | Reusable CEL expression editor with syntax highlighting and autocomplete. |
+| [CEL Registry Search](spp_cel_registry_search) | Search the registry using CEL expressions. |
+| [CEL Vocabulary](spp_cel_vocabulary) | Vocabulary-aware CEL functions for eligibility rules. |
+
+### Change Request Modules
+
+Workflow modules for managing data change requests.
+
+| Module | Summary |
+| --- | --- |
+| [Change Request V2](spp_change_request_v2) | Configuration-driven change request system with conflict detection and duplicate prevention. |
+| [CR Types - Advanced](spp_cr_types_advanced) | Advanced change request types with custom Python strategies. |
+| [CR Types - Base](spp_cr_types_base) | Basic change request types with field mapping strategy. |
+
+### DRIMS Modules
+
+Disaster Response Inventory Management System.
+
+| Module | Summary |
+| --- | --- |
+| [DRIMS](spp_drims) | Disaster relief inventory management for donations, requests, and distribution tracking. |
+| [DRIMS - Sri Lanka](spp_drims_sl) | Sri Lanka-specific configuration for DRIMS with geographic hierarchy and approval thresholds. |
+| [DRIMS - Sri Lanka Demo](spp_drims_sl_demo) | Demo data generator for DRIMS Sri Lanka implementation. |
+
+### Farmer Registry Modules
+
+Modules for agricultural beneficiary management.
+
+| Module | Summary |
+| --- | --- |
+| [Farmer Registry](spp_farmer_registry) | Farm details, agricultural activities, seasons, and CEL variable integration. |
+| [Farmer Registry: Change Requests](spp_farmer_registry_cr) | Farmer-specific change request types for farm details and activities. |
+| [Farmer Registry: Dashboard](spp_farmer_registry_dashboard) | Dashboard with CEL-based metrics and trends for farmer data. |
+| [Farmer Registry: Demo](spp_farmer_registry_demo) | Demo generator with fixed stories and volume generation. |
+| [Farmer Registry: Vocabularies](spp_farmer_registry_vocabularies) | FAO-aligned vocabularies for crops, livestock, and aquaculture. |
 
 ### GIS Modules
 
 Geographic Information System modules for spatial data and mapping.
 
-| Module                        | Summary                                                                                    |
-| ----------------------------- | ------------------------------------------------------------------------------------------ |
-| [GIS](spp_gis)                | GIS core plus area geo fields and importer extensions (points/polygons, layers, queries). |
-| [GIS Reports](spp_gis_report) | Geographic visualization and reporting for social protection data.                        |
+| Module | Summary |
+| --- | --- |
+| [GIS Indicators](spp_gis_indicators) | Choropleth visualization with color scales and classification methods. |
+| [GIS Reports](spp_gis_report) | Geographic visualization and reporting for social protection data. |
+| [GIS Reports - Programs](spp_gis_report_programs) | Add program context filtering to GIS reports. |
+| [Registrant GIS](spp_registrant_gis) | Adds GPS coordinates to registrants for spatial queries. |
 
-### Monitoring Modules
+### GRM Modules
 
-Modules for audit, compliance, and grievance management.
+Grievance Redress Mechanism modules.
 
-| Module                                   | Summary                                                                                                                                                                                                                                                             |
-| ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [Approval](spp_approval)                 | Standardized approval workflows with multi-tier sequencing and CEL rules.                                                                                                                                                                                           |
-| [Audit](spp_audit)                       | Comprehensively tracks all data modifications and user actions across the platform, recording old and new values. It enhances accountability and data integrity by maintaining an immutable history of changes. Supports multiple backends (database, file, syslog, HTTP). |
-| [Grievance Redress Mechanism](spp_grm)   | Provides a centralized Grievance Redress Mechanism for receiving, tracking, and resolving beneficiary complaints and feedback. It supports multi-channel submission and manages resolution workflows through customizable stages.                                   |
+| Module | Summary |
+| --- | --- |
+| [GRM](spp_grm) | Centralized grievance receiving, tracking, and resolution with multi-channel submission. |
+| [GRM: Case Link](spp_grm_case_link) | Links GRM tickets with Case Management for escalation. |
+| [GRM: CEL Rules](spp_grm_cel) | CEL-based routing and escalation rules for GRM tickets. |
+| [GRM: Demo Data](spp_grm_demo) | Demo data generator for GRM with story-based tickets. |
+| [GRM: Programs](spp_grm_programs) | Link GRM tickets to programs, entitlements, and payments. |
+| [GRM: Registry](spp_grm_registry) | Link GRM tickets to registrants with repeat ticket detection. |
 
-### Security & Identity Modules
+### Hazard & Emergency Modules
 
-Modules for access control, encryption, privacy, and security features.
+Modules for disaster and emergency management.
 
-| Module                                 | Summary                                                                                                                                                                                                                                |
-| -------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [Consent](spp_consent)                 | DPV-aligned consent management implementing ISO/IEC TS 27560:2023 for GDPR-compliant consent lifecycle management.                                                                                                                     |
-| [Key Management](spp_key_management)   | Centralized cryptographic key management with pluggable providers.                                                                                                                                                                     |
-| [QR Credentials](spp_claim_169)        | MOSIP Claim 169 QR code identity credential generation for registrants with configurable attribute mapping.                                                                                                                            |
-| [User Roles](spp_user_roles)           | Defines and manages distinct user roles, categorizing them as global or local, to implement area-based access control. It restricts user access to specific geographical areas and automates underlying system permission assignments. |
+| Module | Summary |
+| --- | --- |
+| [Hazard & Emergency Management](spp_hazard) | Hazard classification, incident recording, and impact assessment for emergency response. |
+| [Hazard: Programs](spp_hazard_programs) | Links hazard impacts to program eligibility and emergency entitlements. |
+
+### Indicators & Metrics Modules
+
+Modules for data analytics, indicators, and scoring.
+
+| Module | Summary |
+| --- | --- |
+| [Analytics](spp_analytics) | Query engine for indicators, simulations, and GIS analytics. |
+| [Indicator](spp_indicator) | Publishable indicators based on CEL variables for dashboards, GIS, and APIs. |
+| [Indicator Studio](spp_indicator_studio) | Studio UI for managing publishable indicators. |
+| [Metric](spp_metric) | Unified metric foundation for indicators and simulations. |
+| [Metric Service](spp_metric_service) | Computation services for fairness, distribution, breakdown, and privacy. |
 
 ### Integration Modules
 
 Modules for external system integration and data exchange.
 
-| Module                                            | Summary                                                                                                                                                                                                                                |
-| ------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [Banking](spp_banking)                            | Manages bank account details for registrants and payment processing.                                                                                                                                                                   |
-| [DCI Client](spp_dci_client)                      | Base DCI client infrastructure with OAuth2 and data source management for interoperability.                                                                                                                                            |
-| [DCI Client - CRVS](spp_dci_client_crvs)          | Connect to Civil Registration and Vital Statistics registries via DCI API.                                                                                                                                                             |
-| [DCI Client - Disability](spp_dci_client_dr)      | Connect to Disability Registries via DCI API for disability status verification.                                                                                                                                                       |
-| [DCI Client - IBR](spp_dci_client_ibr)            | Connect to Identity Bureau for duplication checks via DCI API.                                                                                                                                                                         |
-| [DCI Server](spp_dci_server)                      | DCI API server infrastructure with FastAPI routers for receiving external requests.                                                                                                                                                    |
-| [Document Management System](spp_dms)             | Provides a centralized system for managing and organizing program-related documents within a structured directory tree. It facilitates efficient document retrieval through categorization and indexed storage.                        |
-| [Event Data](spp_event_data)                      | Records and tracks events related to individual and group registrants from surveys, field visits, and external systems like ODK and KoBoToolbox.                                                                                       |
-| [Service Points](spp_service_points)              | Manages physical or virtual locations for social protection service delivery, establishing and categorizing operational service points. It links these points to hierarchical geographical areas, company entities, and user accounts. |
-| [Source Tracking](spp_source_tracking)            | Track data provenance and source information for registrants.                                                                                                                                                                          |
-| [Vocabulary](spp_vocabulary)                      | Centralized vocabulary and lookup value management.                                                                                                                                                                                    |
+| Module | Summary |
+| --- | --- |
+| [Banking](spp_banking) | Bank account details for registrants and payment processing. |
+| [DCI Core](spp_dci) | Core DCI (Digital Convergence Initiative) API components and schemas. |
+| [DCI Client](spp_dci_client) | Base DCI client infrastructure with OAuth2 and data source management. |
+| [DCI Client - CRVS](spp_dci_client_crvs) | Connect to Civil Registration and Vital Statistics registries via DCI API. |
+| [DCI Client - Disability](spp_dci_client_dr) | Connect to Disability Registries via DCI API. |
+| [DCI Client - IBR](spp_dci_client_ibr) | Connect to Identity Bureau for duplication checks via DCI API. |
+| [DCI Server](spp_dci_server) | DCI API server infrastructure with FastAPI routers. |
+| [Document Management System](spp_dms) | Centralized document management with directory trees and indexed storage. |
+| [Event Data](spp_event_data) | Records events from surveys, field visits, and external systems (ODK, KoBoToolbox). |
+| [HXL Integration](spp_hxl) | Humanitarian Exchange Language support for data interoperability. |
+| [HXL Area Integration](spp_hxl_area) | HXL import with area-level aggregation for humanitarian indicators. |
+| [Import Match](spp_import_match) | Intelligent import matching to prevent duplication during bulk data onboarding. |
+| [Service Points](spp_service_points) | Manage physical or virtual service delivery locations with area linking. |
+| [Source Tracking](spp_source_tracking) | Track data provenance and source information for registrants. |
+| [Vocabulary](spp_vocabulary) | Centralized vocabulary and lookup value management. |
+
+### Monitoring Modules
+
+Modules for audit, compliance, and approval workflows.
+
+| Module | Summary |
+| --- | --- |
+| [Alerts](spp_alerts) | Generic alert engine for threshold monitoring, expiry tracking, and deadlines. |
+| [Approval](spp_approval) | Standardized approval workflows with multi-tier sequencing and CEL rules. |
+| [Audit](spp_audit) | Immutable change history with multiple backends (database, file, syslog, HTTP). |
+
+### Registry Extensions
+
+Modules extending core registry functionality.
+
+| Module | Summary |
+| --- | --- |
+| [Disability Registry](spp_disability_registry) | WG-SS/CFM disability assessments, assistive device tracking, and CEL functions. |
+| [Graduation](spp_graduation) | Manage graduation and exit from time-bound social protection programs. |
+| [Group Hierarchy](spp_registry_group_hierarchy) | Hierarchical group relationships with nested group structures. |
+| [Registry Search Portal](spp_registry_search) | Search-first registry interface for privacy protection. |
+| [Session Tracking](spp_session_tracking) | Track attendance at required sessions and trainings. |
+
+### Scoring & Targeting Modules
+
+Modules for beneficiary assessment and targeting.
+
+| Module | Summary |
+| --- | --- |
+| [Scoring](spp_scoring) | Configurable scoring and assessment framework for beneficiary targeting. |
+| [Scoring: Programs](spp_scoring_programs) | Integrates scoring with program eligibility and entitlements. |
+| [Simulation](spp_simulation) | Simulate targeting scenarios and analyze fairness before committing. |
+
+### Security & Identity Modules
+
+Modules for access control, encryption, privacy, and security features.
+
+| Module | Summary |
+| --- | --- |
+| [Attachment Antivirus Scan](spp_attachment_av_scan) | ClamAV-based antivirus scanning with quarantine workflow. |
+| [Consent](spp_consent) | DPV-aligned consent management implementing ISO/IEC TS 27560:2023. |
+| [Encryption](spp_encryption) | JWE encryption, JWT signing, and Linked Data Proof signing. |
+| [Key Management](spp_key_management) | Centralized cryptographic key management with pluggable providers. |
+| [QR Credentials](spp_claim_169) | MOSIP Claim 169 QR code identity credentials for registrants. |
+| [User Roles](spp_user_roles) | Area-based access control with global and local role definitions. |
+
+### Studio Modules
+
+No-code configuration tools for implementers.
+
+| Module | Summary |
+| --- | --- |
+| [Custom Fields](spp_custom_field) | Define and add custom data fields to registrant profiles. |
+| [Studio](spp_studio) | No-code customization interface for OpenSPP. |
+| [Studio - API V2](spp_studio_api_v2) | Bridge Studio custom fields and variables with API v2. |
+| [Studio - Change Requests](spp_studio_change_requests) | No-code change request type builder. |
+| [Studio - Events](spp_studio_events) | No-code event type designer for data collection. |
 
 ### Utility Modules
 
 Helper modules providing common utilities and tools.
 
-| Module                                      | Summary                                                                                                                  |
-| ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
-| [Hide Menus: Base](spp_hide_menus_base)     | Administrators can manage the visibility of navigation menus, streamlining the user interface for specific user groups. |
-| [Registry Search Portal](spp_registry_search) | Search-first registry interface for privacy protection.                                                                |
-| [Versioning](spp_versioning)                | Artifact versioning with scheduled activation.                                                                           |
+| Module | Summary |
+| --- | --- |
+| [Area HDX Integration](spp_area_hdx) | HDX Common Operational Datasets integration for admin boundaries. |
+| [Hide Menus: Base](spp_hide_menus_base) | Manage visibility of navigation menus for specific user groups. |
+| [Irrigation](spp_irrigation) | Irrigation asset management with GIS and water distribution networks. |
+| [Land Record](spp_land_record) | Land parcel records with ownership, lease tracking, and GIS fields. |
+| [Versioning](spp_versioning) | Artifact versioning with scheduled activation. |
 
 ### Starter & Demo Modules
 
 Pre-configured bundles and demonstration data.
 
-| Module                                                | Summary                                                                         |
-| ----------------------------------------------------- | ------------------------------------------------------------------------------- |
-| [Demo](spp_demo)                                      | Core demo module with data generator and sample data.                           |
-| [MIS Demo V2](spp_mis_demo_v2)                        | Demo Generator V2 for SP-MIS programs with fixed stories and volume generation. |
-| [Starter: Social Registry](spp_starter_social_registry) | Complete Social Registry bundle with API, DCI, and Change Request support.    |
-| [Starter: SP-MIS](spp_starter_sp_mis)                 | Complete SP-MIS bundle with Social Registry, Programs, and Service Points.      |
+| Module | Summary |
+| --- | --- |
+| [Demo](spp_demo) | Core demo module with data generator and sample data. |
+| [MIS Demo V2](spp_mis_demo_v2) | Demo Generator V2 for SP-MIS programs with fixed stories and volume generation. |
+| [Starter: Farmer Registry](spp_starter_farmer_registry) | Complete Farmer Registry bundle with API, DCI, and Program support. |
+| [Starter: Social Registry](spp_starter_social_registry) | Complete Social Registry bundle with API, DCI, and Change Request support. |
+| [Starter: SP-MIS](spp_starter_sp_mis) | Complete SP-MIS bundle with Social Registry, Programs, and Service Points. |
 
 ### Theme & Branding
 
-| Module                             | Summary                                                                     |
-| ---------------------------------- | --------------------------------------------------------------------------- |
-| [Branding Kit](spp_branding_kit)   | Branding customization, URL routing (`/openspp`), and telemetry management. |
-| [Theme](theme_openspp_muk)         | OpenSPP visual theme and branding.                                          |
+| Module | Summary |
+| --- | --- |
+| [Branding Kit](spp_branding_kit) | Branding customization, URL routing (`/openspp`), and telemetry management. |
+| [Theme](theme_openspp_muk) | OpenSPP visual theme and branding. |
 
 ```{toctree}
 :maxdepth: 1
 :hidden:
 
+spp_alerts
+spp_analytics
 spp_api_v2
-spp_api_v2_cycles
-spp_api_v2_data
-spp_api_v2_entitlements
-spp_api_v2_products
-spp_api_v2_service_points
-spp_api_v2_vocabulary
 spp_approval
 spp_area
+spp_area_hdx
+spp_attachment_av_scan
 spp_audit
 spp_banking
 spp_base_common
 spp_base_setting
 spp_branding_kit
+spp_case_base
 spp_cel_domain
-spp_cel_widget
 spp_change_request_v2
 spp_claim_169
 spp_consent
-spp_cr_types_advanced
-spp_cr_types_base
 spp_custom_field
-spp_dci_client
-spp_dci_client_crvs
-spp_dci_client_dr
-spp_dci_client_ibr
-spp_dci_server
+spp_dci
 spp_demo
+spp_disability_registry
 spp_dms
+spp_drims
+spp_encryption
 spp_event_data
+spp_farmer_registry
 spp_gis
-spp_gis_report
+spp_graduation
 spp_grm
+spp_hazard
 spp_hide_menus_base
+spp_hxl
+spp_import_match
+spp_indicator
+spp_indicator_studio
+spp_irrigation
 spp_key_management
+spp_land_record
+spp_metric
+spp_metric_service
 spp_mis_demo_v2
+spp_oauth
 spp_programs
+spp_registrant_gis
 spp_registry
+spp_registry_group_hierarchy
 spp_registry_search
+spp_scoring
 spp_security
 spp_service_points
+spp_session_tracking
+spp_simulation
 spp_source_tracking
+spp_starter_farmer_registry
 spp_starter_social_registry
 spp_starter_sp_mis
+spp_storage_backend
 spp_studio
-spp_studio_change_requests
-spp_studio_events
 spp_user_roles
 spp_versioning
 spp_vocabulary

--- a/docs/reference/modules/spp_alerts.md
+++ b/docs/reference/modules/spp_alerts.md
@@ -1,0 +1,69 @@
+---
+openspp:
+  doc_status: draft
+---
+
+# Alerts
+
+**Module:** `spp_alerts`
+
+## Overview
+
+Generic alert engine for threshold monitoring, expiry tracking, and deadline management across OpenSPP modules.
+
+## Purpose
+
+This module is designed to:
+
+- **Monitor thresholds and deadlines:** Automatically detect when numeric fields exceed thresholds or date fields approach deadlines across any Odoo model.
+- **Manage alert lifecycle:** Track alerts through active, acknowledged, and resolved states with full audit trail.
+- **Configure monitoring rules:** Define reusable rules that specify what to monitor, how to compare values, and what priority to assign.
+- **Schedule automated evaluation:** Run alert rules on a cron schedule to continuously monitor system conditions without manual intervention.
+
+## Module Dependencies
+
+| Dependency | Purpose |
+| --- | --- |
+| `base` | Odoo core framework |
+| `mail` | Communication and activity tracking |
+| `spp_security` | Central security definitions for OpenSPP modules |
+| `spp_vocabulary` | OpenSPP: Vocabulary |
+
+## Key Features
+
+### Alert Management
+
+Alerts are the core records that represent detected conditions requiring attention.
+
+| Field | Description |
+| --- | --- |
+| Reference | Auto-generated unique identifier (e.g., ALT/0001) |
+| Alert Type | Classification from the alerts vocabulary |
+| Priority | Low, Medium, High, or Critical |
+| State | Active, Acknowledged, or Resolved |
+| Source Record | Link to the record that triggered the alert |
+| Current Value / Threshold | Numeric values for threshold-based alerts |
+| Days Until | Days remaining for deadline-based alerts |
+
+Alerts support a three-step workflow: **Active** (newly raised) -> **Acknowledged** (seen and being investigated) -> **Resolved** (addressed with resolution notes).
+
+### Alert Rules
+
+Rules define the monitoring criteria for automatically creating alerts. Two rule types are supported:
+
+| Rule Type | Description |
+| --- | --- |
+| Threshold | Compares a numeric field against a configured value using operators: <, <=, >, >=, = |
+| Date / Deadline | Checks if a date field is within N days of today |
+
+Each rule specifies a model to monitor, an optional domain filter, and a default priority. The rule engine checks for existing active/acknowledged alerts before creating duplicates.
+
+### Scheduled Evaluation
+
+A cron job (`_cron_evaluate_rules`) periodically evaluates all active rules. Each rule searches its monitored model, applies the domain filter, and creates alerts for records that match the threshold or deadline condition.
+
+## Integration
+
+- **spp_vocabulary:** Alert types are managed as vocabulary codes under the `urn:openspp:vocab:alerts` namespace, allowing flexible classification without code changes.
+- **mail:** Alerts inherit `mail.thread` for change tracking and message history on each alert record.
+- **Consumer modules:** Other modules (e.g., spp_drims) can extend `spp.alert` and `spp.alert.rule` to add domain-specific fields and behaviors.

--- a/docs/reference/modules/spp_analytics.md
+++ b/docs/reference/modules/spp_analytics.md
@@ -1,0 +1,106 @@
+---
+openspp:
+  doc_status: draft
+---
+
+# Analytics
+
+**Module:** `spp_analytics`
+
+## Overview
+
+Query engine for indicators, simulations, and GIS analytics
+
+## Purpose
+
+This module is designed to:
+
+- **Compute aggregation queries:** Provide a unified entry point for all statistics computation, including counts, indicator values, and demographic breakdowns.
+- **Define targeting scopes:** Resolve sets of registrant IDs from CEL expressions, administrative areas, spatial polygons/buffers, area tags, or explicit ID lists.
+- **Enforce access control:** Restrict what data users can query through configurable access rules with k-anonymity thresholds, scope type restrictions, and dimension limits.
+- **Cache query results:** Store and retrieve aggregation results with TTL-based expiration to improve performance for frequently requested queries.
+
+## Module Dependencies
+
+| Dependency | Purpose |
+| --- | --- |
+| `base` | Odoo core framework |
+| `spp_cel_domain` | Write simple CEL-like expressions to filter records (Open... |
+| `spp_area` | Establishes direct associations between OpenSPP registran... |
+| `spp_registry` | Consolidated registry management for individuals, groups,... |
+| `spp_security` | Central security definitions for OpenSPP modules |
+| `spp_metric_service` | Computation services for fairness, distribution, breakdow... |
+
+## Key Features
+
+### Aggregation Scopes
+
+Scopes define WHAT to aggregate by resolving to a set of registrant IDs. All scope types ultimately produce a list of `res.partner` IDs.
+
+| Scope Type | Description |
+| --- | --- |
+| CEL Expression | Filter registrants using CEL expressions against individual or group profiles |
+| Administrative Area | Select registrants in an area, optionally including child areas |
+| Area Tags | Select registrants in all areas matching specific tags |
+| Within Polygon | Spatial query using GeoJSON polygon (requires PostGIS bridge module) |
+| Within Distance | Spatial buffer query by center point and radius in km |
+| Explicit IDs | Directly specified list of registrant IDs |
+
+Each scope can have caching enabled with a custom TTL and displays an approximate registrant count.
+
+### Analytics Service
+
+The `spp.analytics.service` is the main entry point for all aggregation queries. It accepts a scope (record, ID, or inline dict), a list of statistics to compute, and optional group-by dimensions for demographic breakdowns.
+
+The service resolves the user's access level from `spp.analytics.access.rule` records rather than accepting it as a parameter, preventing callers from bypassing restrictions.
+
+Convenience methods are provided for common patterns:
+
+- `compute_for_area()` -- aggregate by administrative area
+- `compute_for_expression()` -- aggregate by CEL expression
+- `compute_fairness()` -- analyze equity across dimensions
+- `compute_distribution()` -- compute distribution statistics for amounts
+
+### Indicator Registry
+
+The `spp.analytics.indicator.registry` maps statistic names to computation strategies using a lookup chain:
+
+1. Built-in statistics (count, gini coefficient)
+2. `spp.indicator` records (via CEL variables)
+3. `spp.cel.variable` records (direct CEL evaluation)
+
+### Access Control
+
+Access rules determine what level of data access a user or group has:
+
+| Setting | Description |
+| --- | --- |
+| Access Level | Aggregates only (counts/statistics) or individual records |
+| K-anonymity Threshold | Minimum count for a cell before suppression (1-100) |
+| Allowed Scope Types | All, area-based only, or predefined scopes only |
+| Inline Scopes | Whether ad-hoc scope definitions are permitted |
+| Allowed Dimensions | Restrict which demographic dimensions can be used for group-by |
+| Max Group-by Dimensions | Limit on number of simultaneous breakdown dimensions (max 10) |
+| Area Restrictions | Limit queries to specific areas and optionally their children |
+
+User-specific rules take precedence over group-based rules, evaluated in sequence order.
+
+### Result Caching
+
+Aggregation results are cached with scope-type-specific TTLs:
+
+| Scope Type | TTL |
+| --- | --- |
+| Area / Area Tags | 1 hour |
+| CEL Expression | 15 minutes |
+| Explicit IDs | 30 minutes |
+| Spatial Polygon / Buffer | No cache |
+
+A scheduled cron job cleans up expired cache entries. Scopes can also be manually refreshed.
+
+## Integration
+
+- **spp_cel_domain:** CEL expressions are compiled and evaluated via the CEL executor service to resolve registrants matching targeting criteria.
+- **spp_area:** Area-based scopes resolve registrants by searching `res.partner` records linked to areas (including child areas and indirect membership through groups).
+- **spp_metric_service:** Privacy enforcement (k-anonymity suppression), fairness analysis, distribution statistics, and demographic breakdowns are delegated to the metric service layer.
+- **spp_api_v2_simulation / spp_api_v2_gis:** These API modules consume the analytics service as their statistics computation backend.

--- a/docs/reference/modules/spp_api_v2.md
+++ b/docs/reference/modules/spp_api_v2.md
@@ -23,16 +23,22 @@ This module is designed to:
 
 ## Module Dependencies
 
-| Dependency              | Description                                               |
-| ----------------------- | --------------------------------------------------------- |
-| **base**                | Odoo base module                                          |
-| **fastapi**             | FastAPI integration for Odoo                              |
-| **spp_security**        | Central security definitions for access control           |
-| **spp_registry**        | Registry models for individuals and groups                |
-| **spp_consent**         | Consent management for data access authorization          |
-| **spp_vocabulary**      | Standardized vocabularies for gender, relationships, etc. |
-| **spp_programs**        | Program and membership management                         |
-| **spp_source_tracking** | Data provenance tracking                                  |
+| Dependency | Purpose |
+| --- | --- |
+| `base` | Odoo core framework |
+| `fastapi` | FastAPI integration for Odoo |
+| `spp_security` | Central security definitions for OpenSPP modules |
+| `spp_registry` | Consolidated registry management for individuals, groups,... |
+| `spp_consent` | DPV-aligned consent management for social protection prog... |
+| `spp_vocabulary` | OpenSPP: Vocabulary |
+| `spp_programs` | Manage cash and in-kind entitlements, integrate with inve... |
+| `spp_source_tracking` | Track data provenance and source information for registrants |
+
+### External Dependencies
+
+| Package | Purpose |
+| --- | --- |
+| `pyjwt` | |
 
 ## Key Features
 
@@ -130,3 +136,18 @@ This module implements patterns defined in:
 - **ADR-007:** Namespace URIs for Identifiers
 - **ADR-008:** Source Tracking and Provenance
 - **ADR-009:** Terminology System
+
+```{toctree}
+:maxdepth: 1
+:hidden:
+
+spp_api_v2_change_request
+spp_api_v2_cycles
+spp_api_v2_data
+spp_api_v2_entitlements
+spp_api_v2_gis
+spp_api_v2_products
+spp_api_v2_service_points
+spp_api_v2_simulation
+spp_api_v2_vocabulary
+```

--- a/docs/reference/modules/spp_api_v2_change_request.md
+++ b/docs/reference/modules/spp_api_v2_change_request.md
@@ -1,0 +1,82 @@
+---
+openspp:
+  doc_status: draft
+---
+
+# Change Request
+
+**Module:** `spp_api_v2_change_request`
+
+## Overview
+
+REST API endpoints for Change Request V2.
+
+## Purpose
+
+This module is designed to:
+
+- **Expose change request operations via REST API:** Allow external systems to create, read, update, and search change requests through authenticated HTTP endpoints.
+- **Manage approval workflow via API:** Support the full change request lifecycle (submit, approve, reject, request revision, apply, reset) through dedicated action endpoints.
+- **Provide type discovery:** Let API consumers discover available change request types and their field schemas before creating requests.
+
+## Module Dependencies
+
+| Dependency | Purpose |
+| --- | --- |
+| `spp_api_v2` | OpenSPP API V2 - Standards-aligned, consent-respecting AP... |
+| `spp_change_request_v2` | Configuration-driven change request system with UX improv... |
+
+## Key Features
+
+### CRUD Endpoints
+
+| Method | Path | Description |
+| --- | --- | --- |
+| POST | `/ChangeRequest` | Create a new change request in draft status |
+| GET | `/ChangeRequest/{ref}` | Read a change request by its reference (e.g., CR/2026/00001) |
+| PUT | `/ChangeRequest/{ref}` | Update detail data on a draft change request |
+| GET | `/ChangeRequest` | Search change requests with filters and pagination |
+
+The reference uses a three-segment path (`{p1}/{p2}/{p3}`) to handle slashes in identifiers like `CR/2026/00001`.
+
+Search supports filtering by registrant identifier, request type, status, and date range. Results are paginated with configurable count and offset.
+
+### Workflow Actions
+
+| Action | Path | Description |
+| --- | --- | --- |
+| Submit | `POST /{ref}/$submit` | Submit a draft change request for approval |
+| Approve | `POST /{ref}/$approve` | Approve a pending change request (optional comment) |
+| Reject | `POST /{ref}/$reject` | Reject with a required reason |
+| Request Revision | `POST /{ref}/$request-revision` | Send back for revision with notes |
+| Apply | `POST /{ref}/$apply` | Execute approved changes on the registrant |
+| Reset | `POST /{ref}/$reset` | Reset rejected/revision CR back to draft |
+
+### Type Schema Discovery
+
+| Method | Path | Description |
+| --- | --- | --- |
+| GET | `/ChangeRequest/$types` | List all active change request types with code, name, and target type |
+| GET | `/ChangeRequest/$types/{code}` | Get field definitions and document requirements for a specific type |
+
+### Optimistic Locking
+
+The PUT endpoint supports optimistic locking via the `If-Match` header. The ETag is based on the record's `write_date` timestamp, and a 409 Conflict is returned if the resource was modified by another request.
+
+### Scope-Based Authorization
+
+All endpoints check API client scopes before processing:
+
+| Scope | Operations |
+| --- | --- |
+| `change_request:create` | Create |
+| `change_request:read` | Read, search, list types |
+| `change_request:update` | Update, submit, reset |
+| `change_request:approve` | Approve, reject, request revision |
+| `change_request:apply` | Apply |
+
+## Integration
+
+- **spp_api_v2:** Provides the FastAPI framework, OAuth authentication middleware, and search result pagination schemas.
+- **spp_change_request_v2:** Supplies the underlying change request models, approval workflow logic, and type configuration. The API module delegates all business logic to a `ChangeRequestService` that wraps these models.
+- **Auto-install:** This module auto-installs when both `spp_api_v2` and `spp_change_request_v2` are present.

--- a/docs/reference/modules/spp_api_v2_cycles.md
+++ b/docs/reference/modules/spp_api_v2_cycles.md
@@ -3,7 +3,7 @@ openspp:
   doc_status: draft
 ---
 
-# API V2 - Cycles
+# Cycles
 
 **Module:** `spp_api_v2_cycles`
 
@@ -21,10 +21,10 @@ This module is designed to:
 
 ## Module Dependencies
 
-| Dependency       | Description                                                   |
-| ---------------- | ------------------------------------------------------------- |
-| **spp_api_v2**   | Core API V2 module providing authentication and base patterns |
-| **spp_programs** | Program and cycle management models                           |
+| Dependency | Purpose |
+| --- | --- |
+| `spp_api_v2` | OpenSPP API V2 - Standards-aligned, consent-respecting AP... |
+| `spp_programs` | Manage cash and in-kind entitlements, integrate with inve... |
 
 ## Key Features
 

--- a/docs/reference/modules/spp_api_v2_data.md
+++ b/docs/reference/modules/spp_api_v2_data.md
@@ -3,7 +3,7 @@ openspp:
   doc_status: draft
 ---
 
-# API V2 - Data
+# Data
 
 **Module:** `spp_api_v2_data`
 
@@ -22,10 +22,10 @@ This module is designed to:
 
 ## Module Dependencies
 
-| Dependency         | Description                                                   |
-| ------------------ | ------------------------------------------------------------- |
-| **spp_api_v2**     | Core API V2 module providing authentication and base patterns |
-| **spp_cel_domain** | CEL domain query builder for variable definitions             |
+| Dependency | Purpose |
+| --- | --- |
+| `spp_api_v2` | OpenSPP API V2 - Standards-aligned, consent-respecting AP... |
+| `spp_cel_domain` | Write simple CEL-like expressions to filter records (Open... |
 
 ## Key Features
 

--- a/docs/reference/modules/spp_api_v2_entitlements.md
+++ b/docs/reference/modules/spp_api_v2_entitlements.md
@@ -3,7 +3,7 @@ openspp:
   doc_status: draft
 ---
 
-# API V2 - Entitlements
+# Entitlements
 
 **Module:** `spp_api_v2_entitlements`
 
@@ -22,10 +22,10 @@ This module is designed to:
 
 ## Module Dependencies
 
-| Dependency       | Description                                                   |
-| ---------------- | ------------------------------------------------------------- |
-| **spp_api_v2**   | Core API V2 module providing authentication and base patterns |
-| **spp_programs** | Entitlement models for cash and in-kind transfers             |
+| Dependency | Purpose |
+| --- | --- |
+| `spp_api_v2` | OpenSPP API V2 - Standards-aligned, consent-respecting AP... |
+| `spp_programs` | Manage cash and in-kind entitlements, integrate with inve... |
 
 ## Key Features
 

--- a/docs/reference/modules/spp_api_v2_gis.md
+++ b/docs/reference/modules/spp_api_v2_gis.md
@@ -1,0 +1,91 @@
+---
+openspp:
+  doc_status: draft
+---
+
+# GIS API
+
+**Module:** `spp_api_v2_gis`
+
+## Overview
+
+OGC API - Features compliant GIS endpoints for QGIS and GovStack GIS BB.
+
+## Purpose
+
+This module is designed to:
+
+- **Serve OGC API - Features endpoints:** Provide standards-compliant GIS endpoints for interoperability with QGIS and GovStack GIS Building Block.
+- **Manage geofences:** Allow API clients to create, list, read, update, and delete areas of interest with GeoJSON geometry.
+- **Export spatial data:** Generate GeoPackage or ZIP of GeoJSON files for offline use in desktop GIS applications.
+- **Run spatial and proximity queries:** Compute aggregated statistics for registrants within polygons, buffers, or proximity to reference points.
+
+## Module Dependencies
+
+| Dependency | Purpose |
+| --- | --- |
+| `spp_api_v2` | OpenSPP API V2 - Standards-aligned, consent-respecting AP... |
+| `spp_gis` | GIS core plus area geo fields and importer extensions (po... |
+| `spp_gis_report` | Geographic visualization and reporting for social protect... |
+| `spp_area` | Establishes direct associations between OpenSPP registran... |
+| `spp_hazard` | Provides hazard classification, incident recording, and i... |
+| `spp_vocabulary` | OpenSPP: Vocabulary |
+| `spp_indicator` | Publishable indicators based on CEL variables for dashboa... |
+| `spp_analytics` | Query engine for indicators, simulations, and GIS analytics |
+
+## Key Features
+
+### OGC API - Features
+
+Implements the OGC API - Features Core standard (Part 1: Core) with the following endpoints:
+
+| Method | Path | Description |
+| --- | --- | --- |
+| GET | `/gis/ogc/` | Landing page with API metadata |
+| GET | `/gis/ogc/conformance` | Conformance classes declaration |
+| GET | `/gis/ogc/collections` | List all feature collections |
+| GET | `/gis/ogc/collections/{id}` | Single collection metadata |
+| GET | `/gis/ogc/collections/{id}/items` | Feature items as GeoJSON |
+| GET | `/gis/ogc/collections/{id}/items/{fid}` | Single feature by ID |
+| GET | `/gis/ogc/collections/{id}/qml` | QGIS style file (extension) |
+
+Collections are derived from GIS report data layers and indicator layers. The QML endpoint is a custom extension that generates QGIS styling templates for each collection.
+
+### Geofence Management
+
+Geofences represent saved areas of interest with GeoJSON geometry. The module extends the geofence model with additional types (`service_area`, `targeting_area`) and incident metadata from the hazard module.
+
+| Method | Path | Description |
+| --- | --- | --- |
+| POST | `/gis/geofences` | Create a geofence from GeoJSON |
+| GET | `/gis/geofences` | List geofences with optional type/incident filters |
+| GET | `/gis/geofences/{id}` | Read a single geofence |
+| DELETE | `/gis/geofences/{id}` | Delete a geofence |
+
+### Data Export
+
+| Method | Path | Description |
+| --- | --- | --- |
+| GET | `/gis/export/geopackage` | Export layers as GeoPackage or ZIP of GeoJSON for offline QGIS use |
+
+Supports filtering by layer IDs, admin level, and optional inclusion of user geofences.
+
+### Spatial and Proximity Queries
+
+| Method | Path | Description |
+| --- | --- | --- |
+| POST | `/gis/query/proximity` | Query registrant statistics by proximity to reference points |
+| POST | `/gis/query/spatial` | Query registrant statistics within a GeoJSON polygon or buffer |
+
+Proximity queries accept lists of reference point coordinates with a radius and return aggregated statistics for registrants within or beyond the specified distance. Spatial queries support polygon containment and buffer distance operations.
+
+### Statistics Endpoint
+
+Area-level aggregated statistics are exposed for dashboard consumption, computing indicator values broken down by administrative areas.
+
+## Integration
+
+- **spp_gis / spp_gis_report:** GIS report layers and indicator layers are mapped to OGC feature collections. The catalog service reads layer configurations to build collection metadata.
+- **spp_analytics:** Spatial and proximity queries delegate statistics computation to the analytics service for consistent aggregation with access control.
+- **spp_hazard:** Geofence properties include incident information (code and name) from linked hazard incident records.
+- **spp_api_v2:** Provides the FastAPI framework, OAuth middleware, and scope-based authorization (requires `gis:read` and/or `gis:write` scopes).

--- a/docs/reference/modules/spp_api_v2_products.md
+++ b/docs/reference/modules/spp_api_v2_products.md
@@ -3,7 +3,7 @@ openspp:
   doc_status: draft
 ---
 
-# API V2 - Products
+# Products
 
 **Module:** `spp_api_v2_products`
 
@@ -22,11 +22,11 @@ This module is designed to:
 
 ## Module Dependencies
 
-| Dependency     | Description                                                   |
-| -------------- | ------------------------------------------------------------- |
-| **spp_api_v2** | Core API V2 module providing authentication and base patterns |
-| **product**    | Odoo product management module                                |
-| **uom**        | Odoo unit of measure module                                   |
+| Dependency | Purpose |
+| --- | --- |
+| `spp_api_v2` | OpenSPP API V2 - Standards-aligned, consent-respecting AP... |
+| `product` | Product catalog management |
+| `uom` | Units of measure |
 
 ## Key Features
 

--- a/docs/reference/modules/spp_api_v2_service_points.md
+++ b/docs/reference/modules/spp_api_v2_service_points.md
@@ -3,7 +3,7 @@ openspp:
   doc_status: draft
 ---
 
-# API V2 - Service Points
+# Service Points
 
 **Module:** `spp_api_v2_service_points`
 
@@ -22,10 +22,10 @@ This module is designed to:
 
 ## Module Dependencies
 
-| Dependency             | Description                                                   |
-| ---------------------- | ------------------------------------------------------------- |
-| **spp_api_v2**         | Core API V2 module providing authentication and base patterns |
-| **spp_service_points** | Service point management models                               |
+| Dependency | Purpose |
+| --- | --- |
+| `spp_api_v2` | OpenSPP API V2 - Standards-aligned, consent-respecting AP... |
+| `spp_service_points` | The OpenSPP Service Points module manages physical or vir... |
 
 ## Key Features
 

--- a/docs/reference/modules/spp_api_v2_simulation.md
+++ b/docs/reference/modules/spp_api_v2_simulation.md
@@ -1,0 +1,95 @@
+---
+openspp:
+  doc_status: draft
+---
+
+# Simulation API
+
+**Module:** `spp_api_v2_simulation`
+
+## Overview
+
+REST API for simulation scenario management.
+
+## Purpose
+
+This module is designed to:
+
+- **Manage simulation scenarios via REST API:** Create, read, update, list, and archive simulation scenarios through authenticated endpoints.
+- **Execute simulations via API:** Trigger simulation runs and retrieve results including beneficiary counts and equity scores.
+- **Compare simulation runs:** Create side-by-side comparisons of multiple simulation runs with overlap analysis.
+- **Convert scenarios to programs:** Transform validated simulation scenarios into real programs with CEL eligibility and cash entitlement managers.
+
+## Module Dependencies
+
+| Dependency | Purpose |
+| --- | --- |
+| `spp_api_v2` | OpenSPP API V2 - Standards-aligned, consent-respecting AP... |
+| `spp_simulation` | Simulate targeting scenarios, analyze fairness and distri... |
+| `spp_analytics` | Query engine for indicators, simulations, and GIS analytics |
+
+## Key Features
+
+### Scenario Management
+
+| Method | Path | Description |
+| --- | --- | --- |
+| GET | `/simulation/scenarios` | List scenarios with optional state/category filters and pagination |
+| POST | `/simulation/scenarios` | Create a new scenario with entitlement rules |
+| GET | `/simulation/scenarios/{id}` | Get scenario details including rules, preview counts, and latest results |
+| PUT | `/simulation/scenarios/{id}` | Update a draft scenario |
+| DELETE | `/simulation/scenarios/{id}` | Archive a scenario (soft delete) |
+
+Scenarios include targeting expressions, budget configuration, entitlement rules, and state management (draft -> ready -> archived).
+
+### Scenario Lifecycle Actions
+
+| Method | Path | Description |
+| --- | --- | --- |
+| POST | `/simulation/scenarios/{id}/ready` | Transition scenario from draft to ready state |
+| POST | `/simulation/scenarios/{id}/run` | Execute the simulation (requires `simulation:execute` scope) |
+| POST | `/simulation/scenarios/{id}/convert-to-program` | Convert a ready scenario into a real program (requires `simulation:convert` scope) |
+
+### Simulation Runs
+
+| Method | Path | Description |
+| --- | --- | --- |
+| GET | `/simulation/runs` | List simulation runs with optional scenario/state filters |
+| GET | `/simulation/runs/{id}` | Get run details with beneficiary counts and entitlement totals |
+
+### Run Comparisons
+
+| Method | Path | Description |
+| --- | --- | --- |
+| POST | `/simulation/comparisons` | Create a comparison of 2+ simulation runs |
+| GET | `/simulation/comparisons/{id}` | Get comparison results with per-run metrics and overlap data |
+
+### Templates
+
+| Method | Path | Description |
+| --- | --- | --- |
+| GET | `/simulation/templates` | List active pre-built scenario templates |
+
+### Analytics Endpoints
+
+The module also exposes analytics endpoints for querying aggregated statistics:
+
+| Method | Path | Description |
+| --- | --- | --- |
+| POST | `/simulation/analytics/query` | Compute aggregation with scope, statistics, and group-by dimensions |
+| GET | `/simulation/analytics/statistics` | List available statistics for discovery |
+
+### Scope-Based Authorization
+
+| Scope | Operations |
+| --- | --- |
+| `simulation:read` | List/read scenarios, runs, comparisons, templates, analytics |
+| `simulation:write` | Create/update/archive scenarios, create comparisons |
+| `simulation:execute` | Run simulations |
+| `simulation:convert` | Convert scenarios to programs |
+
+## Integration
+
+- **spp_simulation:** All scenario, run, and comparison business logic is delegated to the simulation models and service layer. The API module provides HTTP transport.
+- **spp_analytics:** Analytics query endpoints delegate to the `spp.analytics.service` for unified statistics computation with access control and caching.
+- **spp_api_v2:** Provides the FastAPI framework, OAuth authentication, and scope-based authorization middleware.

--- a/docs/reference/modules/spp_api_v2_vocabulary.md
+++ b/docs/reference/modules/spp_api_v2_vocabulary.md
@@ -3,7 +3,7 @@ openspp:
   doc_status: draft
 ---
 
-# API V2 - Vocabulary
+# Vocabulary
 
 **Module:** `spp_api_v2_vocabulary`
 
@@ -22,10 +22,10 @@ This module is designed to:
 
 ## Module Dependencies
 
-| Dependency         | Description                                                   |
-| ------------------ | ------------------------------------------------------------- |
-| **spp_api_v2**     | Core API V2 module providing authentication and base patterns |
-| **spp_vocabulary** | Centralized vocabulary and lookup value management            |
+| Dependency | Purpose |
+| --- | --- |
+| `spp_api_v2` | OpenSPP API V2 - Standards-aligned, consent-respecting AP... |
+| `spp_vocabulary` | OpenSPP: Vocabulary |
 
 ## Key Features
 

--- a/docs/reference/modules/spp_approval.md
+++ b/docs/reference/modules/spp_approval.md
@@ -23,13 +23,13 @@ This module is designed to:
 
 ## Module Dependencies
 
-| Dependency        | Description                                     |
-| ----------------- | ----------------------------------------------- |
-| `base`            | Odoo core framework                             |
-| `mail`            | Mail thread and activities for notifications    |
-| `spp_base_common` | Common OpenSPP utilities                        |
-| `spp_cel_domain`  | CEL expression evaluation for conditional rules |
-| `spp_security`    | Security groups and access control              |
+| Dependency | Purpose |
+| --- | --- |
+| `base` | Odoo core framework |
+| `mail` | Communication and activity tracking |
+| `spp_base_common` | The OpenSPP base module that provides the main menu, gene... |
+| `spp_cel_domain` | Write simple CEL-like expressions to filter records (Open... |
+| `spp_security` | Central security definitions for OpenSPP modules |
 
 ## Key Features
 

--- a/docs/reference/modules/spp_area.md
+++ b/docs/reference/modules/spp_area.md
@@ -23,20 +23,20 @@ This module is designed to:
 
 ## Module Dependencies
 
-| Dependency        | Purpose                                   |
-| ----------------- | ----------------------------------------- |
-| `base`            | Odoo core framework                       |
-| `spp_base_common` | OpenSPP main menu and configuration       |
-| `spp_user_roles`  | Area-based role assignments               |
-| `spp_registry`    | Registrant models for area linking        |
-| `queue_job`       | Background processing for bulk operations |
-| `spp_security`    | Security groups and access control        |
+| Dependency | Purpose |
+| --- | --- |
+| `base` | Odoo core framework |
+| `spp_base_common` | The OpenSPP base module that provides the main menu, gene... |
+| `spp_user_roles` | The OpenSPP User Roles module defines and manages distinc... |
+| `spp_registry` | Consolidated registry management for individuals, groups,... |
+| `job_worker` | Background job worker |
+| `spp_security` | Central security definitions for OpenSPP modules |
 
 ### External Dependencies
 
-| Package    | Purpose                                 |
-| ---------- | --------------------------------------- |
-| `openpyxl` | Excel file support for area data import |
+| Package | Purpose |
+| --- | --- |
+| `openpyxl` | |
 
 ## Key Features
 
@@ -164,13 +164,3 @@ Area assignments for access control:
 | Field          | Purpose                                     |
 | -------------- | ------------------------------------------- |
 | Assigned Areas | Areas the user can access (for local roles) |
-
-## Technical Details
-
-| Property       | Value        |
-| -------------- | ------------ |
-| Technical Name | `spp_area`   |
-| Category       | OpenSPP/Core |
-| Version        | 19.0.1.3.1   |
-| License        | LGPL-3       |
-| Application    | Yes          |

--- a/docs/reference/modules/spp_area_hdx.md
+++ b/docs/reference/modules/spp_area_hdx.md
@@ -1,0 +1,92 @@
+---
+openspp:
+  doc_status: draft
+---
+
+# HDX COD Integration
+
+**Module:** `spp_area_hdx`
+
+## Overview
+
+HDX Common Operational Datasets (COD) integration for downloading admin boundaries with polygons. Supports humanitarian coordination with P-code standardization and GPS-based area lookup.
+
+## Purpose
+
+This module is designed to:
+
+- **Import administrative boundaries from HDX:** Download Common Operational Datasets (COD) from the Humanitarian Data Exchange, including GeoJSON polygons for admin boundary areas.
+- **Standardize P-codes:** Store and look up areas using official P-codes from COD datasets, enabling interoperability with humanitarian coordination systems.
+- **Locate areas by GPS coordinates:** Find which administrative area contains a given GPS point using PostGIS spatial queries.
+
+## Module Dependencies
+
+| Dependency | Purpose |
+| --- | --- |
+| `spp_area` | Establishes direct associations between OpenSPP registran... |
+| `spp_gis` | GIS core plus area geo fields and importer extensions (po... |
+
+### External Dependencies
+
+| Package | Purpose |
+| --- | --- |
+| `requests` | HTTP client for downloading datasets from the HDX API |
+| `geojson` | Parsing and validating GeoJSON geometry data |
+
+## Key Features
+
+### COD Source Management
+
+The `spp.hdx.cod.source` model maintains a registry of COD datasets per country. Each source tracks:
+
+| Field | Description |
+| --- | --- |
+| Country | Country linked to the COD dataset |
+| HDX Dataset ID | Identifier on HDX (e.g., `cod-ab-lka`) |
+| Resources | GeoJSON resources available at each admin level |
+| Last Sync / Import | Timestamps of most recent operations |
+
+The **Sync from HDX** action fetches dataset metadata from the HDX API and creates resource records for each available admin level.
+
+### COD Resource Tracking
+
+Each `spp.hdx.cod.resource` represents a single admin-level GeoJSON file within a COD dataset. Resources store field mappings (P-code field, name field, parent P-code field) and track download history and feature counts.
+
+### Import Wizard
+
+A multi-step wizard (`spp.hdx.cod.import.wizard`) supports two import modes:
+
+| Mode | Description |
+| --- | --- |
+| Download from HDX | Fetch GeoJSON directly from the HDX API for selected admin levels |
+| Upload GeoJSON File | Import from a manually uploaded GeoJSON file |
+
+The wizard provides a preview step showing counts of areas to update, P-codes not found, and new areas to create. Import options include:
+
+- **Update existing areas** matched by P-code with new polygons
+- **Create missing areas** for unmatched P-codes
+- **Update names** from COD data
+
+Field mappings for P-code, name, local name, and parent P-code are auto-detected from GeoJSON properties or can be set manually. Features are processed in batches of 100 for efficiency.
+
+### GPS-Based Area Lookup
+
+The module extends `spp.area` with PostGIS spatial query methods:
+
+| Method | Description |
+| --- | --- |
+| `find_by_coordinates(lat, lon, level)` | Find the most specific area containing a GPS point, optionally filtered by admin level |
+| `find_all_containing(lat, lon)` | Return all areas at all levels containing the point, ordered from country level to most specific |
+| `find_by_pcode(pcode)` | Look up an area by HDX P-code, falling back to the code field |
+
+### HDX-Specific Area Fields
+
+| Field | Description |
+| --- | --- |
+| `hdx_pcode` | Official P-code from COD dataset (unique, indexed) |
+| `hdx_last_update` | Timestamp of last update from HDX |
+
+## Integration
+
+- **spp_area:** Extends the `spp.area` model with HDX P-code fields and GPS lookup methods. Imported boundaries update existing area records matched by P-code or code.
+- **spp_gis:** Uses the `geo_polygon` PostGIS geometry column for spatial containment queries (`ST_Contains`). Imported GeoJSON geometry is stored in this column.

--- a/docs/reference/modules/spp_attachment_av_scan.md
+++ b/docs/reference/modules/spp_attachment_av_scan.md
@@ -1,0 +1,101 @@
+---
+openspp:
+  doc_status: draft
+---
+
+# Attachment Antivirus Scan
+
+**Module:** `spp_attachment_av_scan`
+
+## Overview
+
+OpenSPP Attachment Antivirus Scan module for OpenSPP.
+
+## Purpose
+
+This module is designed to:
+
+- **Scan attachments for malware:** Automatically queue antivirus scans for all binary attachments on creation and update using ClamAV.
+- **Quarantine infected files:** Remove infected file data and store an encrypted backup for forensic analysis, preventing malware from being downloaded.
+- **Manage quarantined files:** Provide AV administrators with tools to restore false positives, download for analysis, or permanently delete quarantined files.
+- **Notify security administrators:** Send internal notifications to the AV Admin group when malware is detected.
+
+## Module Dependencies
+
+| Dependency | Purpose |
+| --- | --- |
+| `base` | Odoo core framework |
+| `mail` | Communication and activity tracking |
+| `job_worker` | Background job worker |
+| `spp_encryption` | Implements advanced cryptographic services for OpenSPP, e... |
+| `spp_security` | Central security definitions for OpenSPP modules |
+
+### External Dependencies
+
+| Package | Purpose |
+| --- | --- |
+| `pyclamd` | Python interface to ClamAV daemon for malware scanning |
+
+## Key Features
+
+### Scanner Backend Configuration
+
+The `spp.av.scanner.backend` model configures ClamAV connections. Two backend types are supported:
+
+| Backend Type | Description |
+| --- | --- |
+| ClamAV Unix Socket | Connect via local Unix socket (default: `/var/run/clamav/clamd.sock`) |
+| ClamAV Network | Connect via TCP to a remote ClamAV daemon (host + port) |
+
+Each backend has configurable file size limits (default 100 MB) and scan timeouts (default 60 seconds). A **Test Connection** button verifies connectivity and displays the ClamAV version.
+
+### Automatic Scanning
+
+Every binary attachment is automatically queued for scanning via `job_worker` background jobs when created or updated. The scan lifecycle adds these fields to `ir.attachment`:
+
+| Field | Description |
+| --- | --- |
+| Scan Status | pending, scanning, clean, infected, error, or skipped |
+| Scan Date | When the scan completed |
+| Threat Name | Name of detected malware (if infected) |
+| Is Quarantined | Whether the file has been quarantined |
+
+Files exceeding the configured maximum size are skipped. Attachments can also be manually rescanned via the **Rescan** action.
+
+### Quarantine Workflow
+
+When malware is detected, the module:
+
+1. Marks the attachment as quarantined
+2. Computes a SHA256 hash of the original file
+3. Encrypts the file data using the configured encryption provider
+4. Stores the encrypted backup in the `quarantine_data` field
+5. Removes the original file data (`datas` set to False)
+6. Notifies AV administrators via internal message
+
+Access to quarantined attachment data is blocked at the `read()` level -- any attempt to read `datas` on a quarantined record returns False.
+
+### AV Admin Actions
+
+Users in the `group_av_admin` security group can perform these actions on quarantined files:
+
+| Action | Description |
+| --- | --- |
+| Restore | Decrypt and restore the original file (for false positives), with size and hash verification |
+| Download for Analysis | Decrypt and create a temporary download attachment for forensic analysis |
+| Permanently Delete | Remove both the encrypted backup and the attachment record |
+
+### Automated Cleanup
+
+Two cron jobs maintain the quarantine system:
+
+| Cron Job | Description |
+| --- | --- |
+| Purge Old Quarantined Files | Remove encrypted backups older than the retention period (default 90 days) |
+| Cleanup Forensic Downloads | Delete temporary forensic download attachments after retention period (default 24 hours) |
+
+## Integration
+
+- **job_worker:** Malware scans run as background jobs via `with_delay()`, ensuring attachment creation is not blocked by scan latency.
+- **spp_encryption:** Quarantined file data is encrypted using a JWCrypto encryption provider before storage, and decrypted on restore or forensic download.
+- **mail:** Security notifications for infected files are sent as internal messages to partners of AV admin users.

--- a/docs/reference/modules/spp_audit.md
+++ b/docs/reference/modules/spp_audit.md
@@ -23,20 +23,20 @@ This module is designed to:
 
 ## Module Dependencies
 
-| Dependency           | Description                         |
-| -------------------- | ----------------------------------- |
-| `base`               | Odoo core framework                 |
-| `mail`               | Mail thread for audit notifications |
-| `spp_registry`       | Registry models to audit            |
-| `spp_security`       | Security groups and access control  |
-| `spp_programs`       | Program models to audit             |
-| `spp_service_points` | Service point models to audit       |
+| Dependency | Purpose |
+| --- | --- |
+| `base` | Odoo core framework |
+| `mail` | Communication and activity tracking |
+| `spp_registry` | Consolidated registry management for individuals, groups,... |
+| `spp_security` | Central security definitions for OpenSPP modules |
+| `spp_programs` | Manage cash and in-kind entitlements, integrate with inve... |
+| `spp_service_points` | The OpenSPP Service Points module manages physical or vir... |
 
-### External Python Dependencies
+### External Dependencies
 
-| Package    | Description                             |
-| ---------- | --------------------------------------- |
-| `requests` | HTTP backend for external audit logging |
+| Package | Purpose |
+| --- | --- |
+| `requests` | |
 
 ## Key Features
 

--- a/docs/reference/modules/spp_banking.md
+++ b/docs/reference/modules/spp_banking.md
@@ -22,19 +22,19 @@ This module is designed to:
 
 ## Module Dependencies
 
-| Dependency       | Description                                |
-| ---------------- | ------------------------------------------ |
-| **spp_security** | OpenSPP security framework                 |
-| **base**         | Core Odoo framework                        |
-| **mail**         | Messaging support                          |
-| **contacts**     | Contact management                         |
-| **spp_registry** | OpenSPP registry for registrant management |
+| Dependency | Purpose |
+| --- | --- |
+| `spp_security` | Central security definitions for OpenSPP modules |
+| `base` | Odoo core framework |
+| `mail` | Communication and activity tracking |
+| `contacts` | Base contact model extension |
+| `spp_registry` | Consolidated registry management for individuals, groups,... |
 
-### External Python Dependencies
+### External Dependencies
 
-| Package      | Description                                |
-| ------------ | ------------------------------------------ |
-| **schwifty** | IBAN/BIC validation and generation library |
+| Package | Purpose |
+| --- | --- |
+| `schwifty` | |
 
 ## Key Features
 
@@ -122,25 +122,3 @@ The module adds bank details views for:
 - Group registrants
 
 These views integrate with the standard registrant forms.
-
-## Technical Details
-
-### IBAN Computation
-
-```
-IBAN = Country Code + Check Digits + Bank Code + Account Number
-```
-
-The `schwifty` library handles:
-
-- Country-specific formatting rules
-- Check digit calculation
-- Validation of the generated IBAN
-
-### Error Handling
-
-If IBAN generation fails (invalid data), the field remains empty and a warning is logged. This prevents blocking record saves due to incomplete bank data.
-
-### Migration Support
-
-The module includes pre-migration scripts (`19.0.1.0.0`) to handle upgrades from previous versions.

--- a/docs/reference/modules/spp_base_common.md
+++ b/docs/reference/modules/spp_base_common.md
@@ -23,14 +23,14 @@ This module is designed to:
 
 ## Module Dependencies
 
-| Dependency            | Purpose                                                          |
-| --------------------- | ---------------------------------------------------------------- |
-| `base`                | Odoo core framework                                              |
-| `spp_user_roles`      | Role-based access control with global and local role definitions |
-| `spp_hide_menus_base` | Menu visibility management for cleaner UI                        |
-| `spp_base_setting`    | Country office and organizational configuration                  |
-| `spp_registry`        | Core beneficiary and group registry                              |
-| `spp_security`        | Central security group and privilege definitions                 |
+| Dependency | Purpose |
+| --- | --- |
+| `base` | Odoo core framework |
+| `spp_user_roles` | The OpenSPP User Roles module defines and manages distinc... |
+| `spp_hide_menus_base` | Administrators can manage the visibility of OpenSPP navig... |
+| `spp_base_setting` | OpenSPP Base Setting provides fundamental configurations ... |
+| `spp_registry` | Consolidated registry management for individuals, groups,... |
+| `spp_security` | Central security definitions for OpenSPP modules |
 
 ## Key Features
 
@@ -80,16 +80,6 @@ Implementation-specific modules (e.g., for a specific country deployment) should
     # Implementation-specific dependencies
 ]
 ```
-
-## Technical Details
-
-| Property       | Value                      |
-| -------------- | -------------------------- |
-| Technical Name | `spp_base_common`          |
-| Category       | OpenSPP/Core               |
-| Version        | 19.0.1.3.0                 |
-| License        | LGPL-3                     |
-| Application    | No (infrastructure module) |
 
 ## See Also
 

--- a/docs/reference/modules/spp_base_setting.md
+++ b/docs/reference/modules/spp_base_setting.md
@@ -22,11 +22,11 @@ This module is designed to:
 
 ## Module Dependencies
 
-| Dependency     | Purpose                                                |
-| -------------- | ------------------------------------------------------ |
-| `base`         | Odoo core framework                                    |
-| `spp_security` | Security groups and access control definitions         |
-| `spp_registry` | Registry model integration for user-registrant linking |
+| Dependency | Purpose |
+| --- | --- |
+| `spp_security` | Central security definitions for OpenSPP modules |
+| `base` | Odoo core framework |
+| `spp_registry` | Consolidated registry management for individuals, groups,... |
 
 ## Key Features
 
@@ -81,16 +81,6 @@ Together, these determine what a user can do and which data they can access.
 2. Assign users to their appropriate office
 3. Configure area assignments for geographic access control
 4. Apply role-based permissions for functionality access
-
-## Technical Details
-
-| Property       | Value                     |
-| -------------- | ------------------------- |
-| Technical Name | `spp_base_setting`        |
-| Category       | OpenSPP/Core              |
-| Version        | 19.0.1.3.1                |
-| License        | LGPL-3                    |
-| Application    | No (configuration module) |
 
 ## See Also
 

--- a/docs/reference/modules/spp_branding_kit.md
+++ b/docs/reference/modules/spp_branding_kit.md
@@ -23,12 +23,12 @@ Use this module when you need to:
 ## Module Dependencies
 
 | Dependency | Purpose |
-|------------|---------|
+| --- | --- |
+| `spp_security` | Central security definitions for OpenSPP modules |
 | `base` | Odoo core framework |
 | `web` | Web interface components |
-| `base_setup` | Configuration settings framework |
-| `spp_security` | Security groups and access control |
-| `theme_openspp_muk` | OpenSPP visual theme styling |
+| `base_setup` | Base setup wizard |
+| `theme_openspp_muk` | OpenSPP Theme |
 
 ## Key Features
 
@@ -97,14 +97,3 @@ This module does not introduce new models. It extends existing Odoo models:
 | `res.config.settings` | Branding and telemetry configuration fields |
 | `ir.http` | Injects OpenSPP branding into session info |
 | `ir.module.module` | Utility to count paid/proprietary apps |
-
-## Technical Details
-
-| Property | Value |
-|----------|-------|
-| Technical Name | `spp_branding_kit` |
-| Category | Theme/Backend |
-| Version | 19.0.1.4.0 |
-| License | LGPL-3 |
-| Application | No |
-| Auto Install | Yes (with base, web) |

--- a/docs/reference/modules/spp_case_base.md
+++ b/docs/reference/modules/spp_case_base.md
@@ -1,0 +1,123 @@
+---
+openspp:
+  doc_status: draft
+---
+
+# Case Management Base
+
+**Module:** `spp_case_base`
+
+## Overview
+
+Core case management functionality for OpenSPP
+
+## Purpose
+
+This module is designed to:
+
+- **Manage social protection cases:** Create and track cases for individuals, households, or groups through a configurable stage-based workflow.
+- **Plan and track interventions:** Build versioned intervention plans with goals, expected outcomes, and individual intervention tasks that track progress.
+- **Record case activities:** Log visits (home, office, phone, virtual), case notes, assessments, and service referrals with full history.
+- **Automate review scheduling:** Cron-based reminders for overdue and upcoming case reviews with Odoo activity integration.
+
+## Module Dependencies
+
+| Dependency | Purpose |
+| --- | --- |
+| `base` | Odoo core framework |
+| `mail` | Communication and activity tracking |
+| `portal` | Portal access capabilities |
+| `spp_security` | Central security definitions for OpenSPP modules |
+
+## Key Features
+
+### Case Records
+
+Each case (`spp.case`) tracks a client through the case management lifecycle with these core attributes:
+
+| Field | Description |
+| --- | --- |
+| Case Number | Auto-generated reference (e.g., CASE-2026-00001) |
+| Case Type | Configurable type classification |
+| Intensity Level | Level 1 (Low), Level 2 (Medium), or Level 3 (High) |
+| Priority | Low, Medium, High, or Urgent |
+| Client | Link to a `res.partner` record (individual, household, or group) |
+| Stage | Configurable workflow stage (supports kanban views) |
+| Case Worker | Assigned user responsible for the case |
+| Supervisor / Team | Optional supervisory assignment |
+| Intake Source | Walk-in, referral, outreach, GRM, program enrollment, or other |
+
+Cases also track risk factors, vulnerabilities, presenting issues, review dates, and closure information (reason, outcome, summary).
+
+### Workflow Stages
+
+Stages (`spp.case.stage`) are fully configurable with:
+
+- Phase classification (intake, assessment, planning, implementation, monitoring, closure)
+- Closed flag for terminal stages
+- Plan requirement flag (blocks entry if no approved intervention plan)
+- Minimum intensity level requirement
+- Kanban view support with `group_expand`
+
+### Intervention Plans
+
+Plans (`spp.case.intervention.plan`) support a versioned approval workflow:
+
+| State | Description |
+| --- | --- |
+| Draft | Initial creation |
+| Pending Approval | Submitted for supervisor review |
+| Approved | Approved with recorded approver and date |
+| Active | Currently being implemented |
+| Completed | All interventions finished |
+| Revised | Superseded by a new version |
+
+Each plan version links to its predecessor. Only one plan per case can be marked as current. Plans contain individual interventions (`spp.case.intervention`) with target dates, completion tracking, and progress percentage calculation.
+
+### Case Activities
+
+| Model | Description |
+| --- | --- |
+| `spp.case.visit` | Home, office, phone, or virtual visits with purpose and notes |
+| `spp.case.note` | Progress notes, assessments, general notes, and supervision notes |
+| `spp.case.referral` | Service referrals with status tracking |
+| `spp.case.assessment` | Structured assessments linked to cases |
+
+### Review Management
+
+A cron job checks for overdue case reviews and creates Odoo activities for case workers:
+
+- Overdue reviews generate immediate todo activities
+- Reviews due within 3 days generate warning activities (if not already created)
+- Review frequency is configurable per case type, defaulting to 30 days
+
+### Case Configuration
+
+| Model | Description |
+| --- | --- |
+| `spp.case.type` | Case type definitions with default intensity and review frequency |
+| `spp.case.stage` | Workflow stage configuration |
+| `spp.case.risk.factor` | Risk factor taxonomy |
+| `spp.case.vulnerability` | Vulnerability taxonomy |
+| `spp.case.closure.reason` | Closure reason options |
+| `spp.case.team` | Team definitions with members and supervisor |
+
+## Integration
+
+- **mail:** Cases and intervention plans inherit `mail.thread` for change tracking. Cases also inherit `mail.activity.mixin` for scheduled review activities.
+- **spp_security:** Security groups and record rules control access to case data based on user roles.
+- **spp_case_cel:** Extends case creation to apply CEL-based triage and assignment rules automatically (optional module).
+- **spp_case_demo:** Provides a demo data generator for populating case management with realistic test data (optional module).
+
+```{toctree}
+:maxdepth: 1
+:hidden:
+
+spp_case_cel
+spp_case_demo
+spp_case_entitlements
+spp_case_graduation
+spp_case_programs
+spp_case_registry
+spp_case_session
+```

--- a/docs/reference/modules/spp_case_cel.md
+++ b/docs/reference/modules/spp_case_cel.md
@@ -1,0 +1,72 @@
+---
+openspp:
+  doc_status: draft
+---
+
+# CEL Rules
+
+**Module:** `spp_case_cel`
+
+## Overview
+
+CEL-based triage and assignment rules for case management
+
+## Purpose
+
+This module is designed to:
+
+- **Automatically triage new cases:** Evaluate CEL expressions against case properties on creation to set intensity level, priority, case type, risk factors, and vulnerabilities.
+- **Automatically assign cases:** Match cases to teams and workers based on CEL conditions, with optional workload balancing across team members.
+
+## Module Dependencies
+
+| Dependency | Purpose |
+| --- | --- |
+| `spp_security` | Central security definitions for OpenSPP modules |
+| `spp_case_base` | Core case management functionality for OpenSPP |
+| `spp_cel_domain` | Write simple CEL-like expressions to filter records (Open... |
+
+## Key Features
+
+### Triage Rules
+
+Triage rules (`spp.case.triage.rule`) automatically categorize and prioritize new cases. Rules are evaluated in sequence order, and the first matching rule is applied.
+
+| Field | Description |
+| --- | --- |
+| Condition (CEL) | CEL expression evaluated against case context |
+| Set Intensity Level | Override intensity to Level 1, 2, or 3 |
+| Set Priority | Override priority to low, medium, high, or urgent |
+| Set Case Type | Override the case type |
+| Add Risk Factors | Risk factors to attach to matching cases |
+| Add Vulnerabilities | Vulnerabilities to attach to matching cases |
+
+Available context variables in CEL expressions: `case`, `client`, `case_type`, `intake_source`, `client_type`, `presenting_issue`, `risk_factors`, `vulnerabilities`.
+
+### Assignment Rules
+
+Assignment rules (`spp.case.assignment.rule`) determine which case worker or team should handle a case. Rules are evaluated in sequence order after triage, only when no case worker is already assigned.
+
+| Field | Description |
+| --- | --- |
+| Condition (CEL) | CEL expression evaluated against case context |
+| Assign to Team | Team to assign the case to |
+| Assign to Worker | Specific case worker to assign |
+| Assign Supervisor | Supervisor to assign |
+| Consider Workload | If enabled, assigns to the team member with the lowest active caseload |
+| Max Cases per Worker | Skip workers at or above this active case count (default 25) |
+
+Available context variables: `case`, `case_type`, `intensity`, `priority`, `client`, `client_type`, `intake_source`.
+
+### Workload Balancing
+
+When workload consideration is enabled on an assignment rule, the module counts each team member's active cases and assigns the case to the member with the lowest caseload, skipping anyone who has reached the maximum case limit.
+
+### Match Statistics
+
+Both triage and assignment rules track how many cases they have matched, providing visibility into rule effectiveness.
+
+## Integration
+
+- **spp_case_base:** Extends the `spp.case` model's `create()` method to apply triage rules first, then assignment rules. This runs automatically on every new case.
+- **spp_cel_domain:** CEL expressions are parsed and evaluated using the `cel_parser` module. Expressions support comparison operators, boolean logic, and access to Odoo record fields through the context variables.

--- a/docs/reference/modules/spp_case_demo.md
+++ b/docs/reference/modules/spp_case_demo.md
@@ -1,0 +1,83 @@
+---
+openspp:
+  doc_status: draft
+---
+
+# Demo Data
+
+**Module:** `spp_case_demo`
+
+## Overview
+
+Demo data generator for Case Management
+
+## Purpose
+
+This module is designed to:
+
+- **Generate realistic demo data:** Populate the case management system with configurable volumes of cases, intervention plans, visits, notes, and referrals for testing and demonstration.
+- **Provide fixed demo stories:** Create predictable named case scenarios with scripted journeys through the case lifecycle for consistent demonstrations.
+- **Supply base configuration:** Install case types (Child Protection, Livelihood Support, etc.) and workflow stages (Intake through Closure) as XML data.
+
+## Module Dependencies
+
+| Dependency | Purpose |
+| --- | --- |
+| `spp_demo` | Core demo module with data generator and sample data for ... |
+| `spp_case_base` | Core case management functionality for OpenSPP |
+| `spp_security` | Central security definitions for OpenSPP modules |
+
+### External Dependencies
+
+| Package | Purpose |
+| --- | --- |
+| `faker` | Generate realistic names, paragraphs, and sentences for demo content |
+
+## Key Features
+
+### Demo Data Wizard
+
+A transient model wizard (`spp.case.demo.generator`) provides configurable generation of case management demo data:
+
+| Setting | Default | Description |
+| --- | --- | --- |
+| Number of Cases | 25 | Total cases to generate (1 to 5,000) |
+| Include Demo Stories | Yes | Generate fixed demo stories with predictable names |
+| Days Back | 120 | Distribute case creation dates within this time window |
+| % with Plans | 70% | Percentage of cases with intervention plans |
+| % with Visits | 60% | Percentage of cases with visit records |
+| % with Notes | 80% | Percentage of cases with progress notes |
+| % Closed | 40% | Percentage of cases in closed state |
+| Link to Beneficiaries | Yes | Link cases to existing registrants |
+| Locale | Company country | Faker locale for generating realistic content |
+
+### Demo Stories
+
+Fixed demo stories define specific case scenarios with scripted journeys. Each story specifies a client profile, case configuration, and a sequence of journey actions:
+
+| Action | Description |
+| --- | --- |
+| intake | Initial case opening |
+| create_plan | Create an intervention plan with goals |
+| add_intervention | Add an intervention task to the current plan |
+| complete_intervention | Mark an intervention as completed |
+| home_visit / office_visit | Record a visit |
+| progress_note | Add a progress note |
+| assessment | Record an assessment |
+| add_referral | Create a service referral |
+| close_case | Close the case and mark plans as completed |
+
+### Random Case Generation
+
+Beyond fixed stories, the wizard generates random cases with:
+
+- Random case types and stages (weighted toward middle stages)
+- Random beneficiary assignments from existing registrants
+- Realistic presenting issues (financial hardship, housing assistance, health support, etc.)
+- Random intake sources, priorities, and intensity levels
+- Backdated creation dates distributed across the configured time window
+
+## Integration
+
+- **spp_case_base:** Creates `spp.case`, `spp.case.intervention.plan`, `spp.case.intervention`, `spp.case.visit`, `spp.case.note`, and `spp.case.referral` records using the base case management models.
+- **spp_demo:** Depends on the core demo module infrastructure. Uses `res.partner` registrants as case clients when "Link to Beneficiaries" is enabled.

--- a/docs/reference/modules/spp_case_entitlements.md
+++ b/docs/reference/modules/spp_case_entitlements.md
@@ -1,0 +1,63 @@
+---
+openspp:
+  doc_status: draft
+---
+
+# Entitlements Integration
+
+**Module:** `spp_case_entitlements`
+
+## Overview
+
+Links cases to program entitlements for case-entitlement relationship management
+
+## Purpose
+
+This module is designed to:
+
+- **Link cases to entitlements:** Associate program entitlements with case records for unified case-entitlement tracking.
+- **Track entitlement status:** Compute and store counts of total, approved, and pending entitlements per case.
+- **Calculate entitlement values:** Sum the total monetary value of approved entitlements linked to a case.
+
+## Module Dependencies
+
+| Dependency | Purpose |
+| --- | --- |
+| `spp_security` | Central security definitions for OpenSPP modules |
+| `spp_case_base` | Core case management functionality for OpenSPP |
+| `spp_programs` | Manage cash and in-kind entitlements, integrate with inve... |
+
+## Key Features
+
+### Entitlement Relationship
+
+Cases are linked to entitlements through a many-to-many relationship. When a partner is selected on a case, entitlements for that partner are automatically loaded.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `entitlement_ids` | Many2many | Entitlements related to the case |
+| `entitlement_count` | Integer | Total number of linked entitlements |
+| `has_entitlements` | Boolean | Whether the case has any entitlements |
+
+### Status Tracking
+
+The module computes entitlement status breakdowns from linked entitlement states.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `approved_entitlement_count` | Integer | Number of approved entitlements |
+| `pending_entitlement_count` | Integer | Number of pending entitlements |
+| `total_entitlement_amount` | Monetary | Sum of approved entitlement amounts |
+
+### Quick Actions
+
+The module provides action buttons to view filtered entitlement lists directly from a case:
+
+- View all entitlements
+- View only approved entitlements
+- View only pending entitlements
+
+## Integration
+
+- **spp_case_base:** Extends the `spp.case` model with entitlement fields and computed statistics.
+- **spp_programs:** Reads from `spp.entitlement` records to populate case-level entitlement data. Auto-installs when both `spp_case_base` and `spp_programs` are present.

--- a/docs/reference/modules/spp_case_graduation.md
+++ b/docs/reference/modules/spp_case_graduation.md
@@ -1,0 +1,63 @@
+---
+openspp:
+  doc_status: draft
+---
+
+# Graduation Integration
+
+**Module:** `spp_case_graduation`
+
+## Overview
+
+Link graduation assessments to cases for exit management
+
+## Purpose
+
+This module is designed to:
+
+- **Link cases to graduation assessments:** Associate graduation assessment records with cases so that exit management is tracked within the case workflow.
+- **Track graduation readiness:** Compute graduation status, readiness score, and assessment counts directly on the case record.
+- **Create assessments from cases:** Provide quick actions to create new graduation assessments pre-filled with case and partner context.
+
+## Module Dependencies
+
+| Dependency | Purpose |
+| --- | --- |
+| `spp_security` | Central security definitions for OpenSPP modules |
+| `spp_case_base` | Core case management functionality for OpenSPP |
+| `spp_graduation` | Manage graduation and exit from time-bound social protect... |
+
+## Key Features
+
+### Graduation Tracking on Cases
+
+Each case computes graduation statistics from its linked assessments, sorted by assessment date.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `graduation_assessment_ids` | One2many | All assessments linked to the case |
+| `graduation_assessment_count` | Integer | Number of assessments |
+| `latest_graduation_assessment_id` | Many2one | Most recent assessment |
+| `graduation_readiness` | Float | Readiness score from the latest assessment |
+
+### Graduation Status
+
+The `graduation_status` field is computed from the latest assessment's state and recommendation:
+
+| Status | Condition |
+| --- | --- |
+| `not_assessed` | No assessments exist |
+| `in_progress` | Latest assessment is in draft |
+| `pending_approval` | Latest assessment is submitted |
+| `approved` | Approved with "graduate" recommendation, no graduation date |
+| `graduated` | Approved with graduation date set |
+| `deferred` | Recommendation is "defer" |
+
+### Assessment Back-Link
+
+The module extends `spp.graduation.assessment` with a `case_id` field, enabling assessments to reference back to their originating case.
+
+## Integration
+
+- **spp_case_base:** Extends `spp.case` with graduation assessment fields and computed status.
+- **spp_graduation:** Extends `spp.graduation.assessment` with a `case_id` Many2one field linking assessments back to cases.

--- a/docs/reference/modules/spp_case_programs.md
+++ b/docs/reference/modules/spp_case_programs.md
@@ -1,0 +1,54 @@
+---
+openspp:
+  doc_status: draft
+---
+
+# Programs Integration
+
+**Module:** `spp_case_programs`
+
+## Overview
+
+Links cases to OpenSPP programs and provides compliance tracking
+
+## Purpose
+
+This module is designed to:
+
+- **Link cases to program enrollments:** Associate program membership records with cases to provide program context within case management.
+- **Track program-triggered cases:** Record which program triggered a case (e.g., non-compliance detection).
+- **Display enrollment summaries:** Compute active program counts and enrolled program names directly on the case form.
+
+## Module Dependencies
+
+| Dependency | Purpose |
+| --- | --- |
+| `spp_security` | Central security definitions for OpenSPP modules |
+| `spp_case_base` | Core case management functionality for OpenSPP |
+| `spp_programs` | Manage cash and in-kind entitlements, integrate with inve... |
+
+## Key Features
+
+### Program Enrollment Tracking
+
+When a partner is selected on a case, their program memberships are automatically loaded.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `program_membership_ids` | Many2many | Program enrollments related to the case |
+| `triggered_by_program_id` | Many2one | Program that triggered this case |
+| `has_active_enrollment` | Boolean | Whether the client has active enrollments |
+| `active_program_count` | Integer | Number of active program enrollments |
+| `enrolled_program_names` | Char | Comma-separated list of enrolled program names |
+
+Active enrollments include memberships in `enrolled` or `paused` states.
+
+### Quick Actions
+
+- **View program enrollments:** Open a list of all program memberships linked to the case.
+- **View triggered program:** Navigate directly to the program that triggered the case.
+
+## Integration
+
+- **spp_case_base:** Extends `spp.case` with program enrollment fields and a triggering program reference.
+- **spp_programs:** Reads from `spp.program.membership` to populate enrollment data and links to `spp.program` for the triggering program. Auto-installs when both `spp_case_base` and `spp_programs` are present.

--- a/docs/reference/modules/spp_case_registry.md
+++ b/docs/reference/modules/spp_case_registry.md
@@ -1,0 +1,72 @@
+---
+openspp:
+  doc_status: draft
+---
+
+# Registry Integration
+
+**Module:** `spp_case_registry`
+
+## Overview
+
+OpenSPP Case Registry Integration module for OpenSPP.
+
+## Purpose
+
+This module is designed to:
+
+- **Link cases to registrants and households:** Associate individual registrants, households, and household members with case records.
+- **Detect previous cases:** Automatically find and display previous cases for the same registrant or household.
+- **View cases from registrant profiles:** Add case counts and navigation actions to the registrant (res.partner) form.
+
+## Module Dependencies
+
+| Dependency | Purpose |
+| --- | --- |
+| `spp_security` | Central security definitions for OpenSPP modules |
+| `spp_case_base` | Core case management functionality for OpenSPP |
+| `spp_registry` | Consolidated registry management for individuals, groups,... |
+| `spp_area` | Establishes direct associations between OpenSPP registran... |
+
+## Key Features
+
+### Registrant and Household Links
+
+Cases are enriched with registry-specific fields for individual and group registrants.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `registrant_id` | Many2one | Primary individual registrant (non-group) |
+| `household_id` | Many2one | Related household (group registrant) |
+| `household_member_ids` | Many2many | Other household members involved in the case |
+| `area_id` | Many2one | Geographic area of the client |
+
+When a registrant is selected, the household is auto-populated from group membership, and the area is loaded from the registrant's profile. When a household is selected, its members are auto-loaded.
+
+### Previous Case Detection
+
+The module automatically computes previous cases for the same registrant or household, enabling case workers to review history.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `previous_case_ids` | Many2many | Previous cases for the same registrant/household |
+| `previous_case_count` | Integer | Number of previous cases |
+
+### Registrant-Side Case View
+
+The `res.partner` model is extended with reverse links to cases:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `case_registrant_ids` | One2many | Cases where this partner is the registrant |
+| `case_household_ids` | One2many | Cases where this partner is the household |
+| `case_count` | Integer | Total cases (as registrant or household) |
+| `case_active_count` | Integer | Active cases only |
+
+An action button on the partner form opens all related cases.
+
+## Integration
+
+- **spp_case_base:** Extends `spp.case` with registrant, household, and area fields.
+- **spp_registry:** Uses `spp.group.membership` to resolve household memberships and populate household members.
+- **spp_area:** Links cases to geographic areas via `spp.area`. Auto-installs when both `spp_case_base` and `spp_registry` are present.

--- a/docs/reference/modules/spp_case_session.md
+++ b/docs/reference/modules/spp_case_session.md
@@ -1,0 +1,72 @@
+---
+openspp:
+  doc_status: draft
+---
+
+# Session Integration
+
+**Module:** `spp_case_session`
+
+## Overview
+
+Link sessions and training attendance to cases
+
+## Purpose
+
+This module is designed to:
+
+- **Link cases to required sessions:** Associate training or group sessions with cases so attendance requirements are tracked.
+- **Compute attendance compliance:** Calculate attendance rates and determine compliance status based on session participation.
+- **View cases from sessions:** Provide a reverse link so sessions display their related cases.
+
+## Module Dependencies
+
+| Dependency | Purpose |
+| --- | --- |
+| `spp_security` | Central security definitions for OpenSPP modules |
+| `spp_case_base` | Core case management functionality for OpenSPP |
+| `spp_session_tracking` | Track attendance at required sessions and trainings for s... |
+
+## Key Features
+
+### Session Tracking on Cases
+
+Cases track required sessions and the client's attendance at those sessions.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `session_ids` | Many2many | Sessions the client is expected to attend |
+| `session_attendance_ids` | One2many | Attendance records for linked sessions |
+| `session_count` | Integer | Number of required sessions |
+
+### Attendance Compliance
+
+The module computes an attendance rate and assigns a compliance level:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `session_attendance_rate` | Float | Percentage of required sessions attended |
+| `session_compliance` | Selection | Compliance status based on attendance rate |
+
+Compliance thresholds:
+
+| Status | Attendance Rate |
+| --- | --- |
+| `compliant` | 80% or higher |
+| `partial` | 50% to 79% |
+| `non_compliant` | Below 50% |
+| `not_applicable` | No required sessions |
+
+### Session Back-Link
+
+The `spp.session` model is extended with:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `case_ids` | Many2many | Cases that require attendance at this session |
+| `case_count` | Integer | Number of related cases |
+
+## Integration
+
+- **spp_case_base:** Extends `spp.case` with session tracking fields and compliance computation.
+- **spp_session_tracking:** Links to `spp.session` and reads `spp.session.attendance` records to compute attendance rates. Extends `spp.session` with a reverse link to cases.

--- a/docs/reference/modules/spp_cel_domain.md
+++ b/docs/reference/modules/spp_cel_domain.md
@@ -22,12 +22,12 @@ This module is designed to:
 
 ## Module Dependencies
 
-| Dependency        | Description                                                                  |
-| ----------------- | ---------------------------------------------------------------------------- |
-| `base`            | Odoo core framework                                                          |
-| `spp_base_common` | Common OpenSPP utilities and base models                                     |
-| `spp_security`    | OpenSPP security groups and access control                                   |
-| `spp_registry`    | Registry models for individuals and groups (required for member aggregation) |
+| Dependency | Purpose |
+| --- | --- |
+| `base` | Odoo core framework |
+| `spp_base_common` | The OpenSPP base module that provides the main menu, gene... |
+| `spp_security` | Central security definitions for OpenSPP modules |
+| `spp_registry` | Consolidated registry management for individuals, groups,... |
 
 ## Key Features
 
@@ -133,4 +133,14 @@ validation = service.validate_expression(
     profile="registry_individuals"
 )
 # validation = {"valid": True, "error": None, "explain": "..."}
+```
+
+```{toctree}
+:maxdepth: 1
+:hidden:
+
+spp_cel_event
+spp_cel_registry_search
+spp_cel_vocabulary
+spp_cel_widget
 ```

--- a/docs/reference/modules/spp_cel_event.md
+++ b/docs/reference/modules/spp_cel_event.md
@@ -1,0 +1,100 @@
+---
+openspp:
+  doc_status: draft
+---
+
+# Event Data Integration
+
+**Module:** `spp_cel_event`
+
+## Overview
+
+Integrate event data with CEL expressions for eligibility and entitlement rules
+
+## Purpose
+
+This module is designed to:
+
+- **Query event data in CEL expressions:** Enable CEL expressions to access, filter, and compare values from event data records for eligibility and entitlement rules.
+- **Aggregate event data:** Provide count, sum, average, min, and max aggregation functions over event records within CEL expressions.
+- **Support temporal filtering:** Allow CEL expressions to filter events by named periods (year, quarter, month, week), relative ranges (within N days/months), and explicit date boundaries.
+
+## Module Dependencies
+
+| Dependency | Purpose |
+| --- | --- |
+| `spp_cel_domain` | Write simple CEL-like expressions to filter records (Open... |
+| `spp_event_data` | Records and tracks events related to individual and group... |
+| `spp_studio` | No-code customization interface for OpenSPP |
+
+## Key Features
+
+### Event Access Functions
+
+CEL expressions can access event data using the following functions:
+
+| Function | Description | Example |
+| --- | --- | --- |
+| `event(type, field)` | Get a field value from a registrant's event | `event('survey').income > 500` |
+| `has_event(type)` | Check if a matching event exists | `has_event('assessment', within_days=365)` |
+| `events_count(type)` | Count matching events | `events_count('visit', period=this_year()) >= 3` |
+| `events_sum(type, field)` | Sum a field across events | `events_sum('payment', 'amount', period='2024')` |
+| `events_avg(type, field)` | Average a field across events | `events_avg('survey', 'score') >= 70` |
+| `events_min(type, field)` | Minimum field value across events | `events_min('assessment', 'score')` |
+| `events_max(type, field)` | Maximum field value across events | `events_max('assessment', 'score')` |
+
+### Event Selection Modes
+
+When multiple events match, the `select` parameter controls which event is used:
+
+| Mode | Behavior |
+| --- | --- |
+| `auto` | Uses `active` if event type has one-active-per-registrant, otherwise `latest` |
+| `active` | Only active events |
+| `latest` | Most recent event regardless of state |
+| `latest_active` | Most recent active event |
+| `first` | Oldest event |
+| `any` | Any matching event |
+
+### Temporal Filters
+
+Events can be filtered by time using parameters on event functions:
+
+| Parameter | Description | Example |
+| --- | --- | --- |
+| `period` | Named period string | `period='2024-Q1'` |
+| `within_days` | Events within last N days | `within_days=90` |
+| `within_months` | Events within last N months | `within_months=6` |
+| `after` | Events on or after a date | `after='2024-01'` |
+| `before` | Events on or before a date | `before='2024-06'` |
+
+### Period Helper Functions
+
+Dynamic period generators for use within CEL expressions:
+
+| Function | Returns | Example Output |
+| --- | --- | --- |
+| `this_year()` | Current year | `'2026'` |
+| `last_year()` | Previous year | `'2025'` |
+| `this_quarter()` | Current quarter | `'2026-Q1'` |
+| `last_quarter()` | Previous quarter | `'2025-Q4'` |
+| `this_month()` | Current month | `'2026-03'` |
+| `last_month()` | Previous month | `'2026-02'` |
+| `quarters_ago(n)` | N quarters back | `'2025-Q3'` |
+| `months_ago(n)` | N months back | `'2025-12'` |
+
+Period strings support these formats: `YYYY`, `YYYY-QN`, `YYYY-HN`, `YYYY-MM`, `YYYY-WNN`.
+
+### CEL Variable Event Aggregation
+
+Extends the CEL variable configuration UI to support event-based aggregations. Users can create variables that aggregate over event data by selecting an event type, aggregation function, time range, and field.
+
+### Optimized Execution
+
+The executor uses SQL fast paths for supported operations (simple comparisons, standard aggregations) and falls back to Python evaluation for complex cases such as default values or where predicates.
+
+## Integration
+
+- **spp_cel_domain:** Extends the CEL translator and executor to handle event-specific query plan nodes (`EventValueCompare`, `EventExists`, `EventsAggregate`).
+- **spp_event_data:** Queries `spp.event.data` records and `spp.event.type` configuration for selection mode resolution.
+- **spp_studio:** Extends the CEL variable form to include event aggregation configuration fields. Auto-installs when all three dependencies are present.

--- a/docs/reference/modules/spp_cel_registry_search.md
+++ b/docs/reference/modules/spp_cel_registry_search.md
@@ -1,0 +1,58 @@
+---
+openspp:
+  doc_status: draft
+---
+
+# Registry Search
+
+**Module:** `spp_cel_registry_search`
+
+## Overview
+
+Search the registry using CEL expressions
+
+## Purpose
+
+This module is designed to:
+
+- **Search the registry using CEL expressions:** Provide an advanced search interface that lets users write CEL expressions to find individuals and groups in the registry.
+- **Control access to advanced search:** Restrict the search portal to authorized users through a dedicated security group.
+- **Display search results with pagination:** Show matching registrants in a paginated list with navigation to registrant profiles.
+
+## Module Dependencies
+
+| Dependency | Purpose |
+| --- | --- |
+| `spp_registry` | Consolidated registry management for individuals, groups,... |
+| `spp_cel_domain` | Write simple CEL-like expressions to filter records (Open... |
+| `spp_cel_widget` | Reusable CEL expression editor with syntax highlighting a... |
+
+## Key Features
+
+### Advanced Search Portal
+
+An OWL client action that provides a full-page search interface accessible from the Registry menu. Users can:
+
+- Write CEL expressions using the shared CEL editor with syntax highlighting
+- Select a search profile (Individuals or Groups)
+- View real-time validation of the expression before executing
+- Browse paginated results (50 records per page)
+- Click on any result to open the registrant form
+
+### Security Groups
+
+| Group | Description |
+| --- | --- |
+| `group_cel_search_user` | Grants access to the Advanced Search menu; implies `group_registry_viewer` |
+
+Registry Officers automatically receive CEL Search access through group implication.
+
+### Menu Entry
+
+The module adds an "Advanced Search" menu item under the Registry root menu, visible only to users with the `group_cel_search_user` security group.
+
+## Integration
+
+- **spp_registry:** The search portal is accessible from the Registry menu and opens registrant forms using registry view references.
+- **spp_cel_domain:** Uses `spp.cel.service.compile_expression()` to translate CEL expressions into Odoo domains and retrieve matching records.
+- **spp_cel_widget:** Embeds the shared `CelEditor` component for expression editing with syntax highlighting and validation.

--- a/docs/reference/modules/spp_cel_vocabulary.md
+++ b/docs/reference/modules/spp_cel_vocabulary.md
@@ -1,0 +1,73 @@
+---
+openspp:
+  doc_status: draft
+---
+
+# Vocabulary Integration
+
+**Module:** `spp_cel_vocabulary`
+
+## Overview
+
+Vocabulary-aware CEL functions for robust eligibility rules
+
+## Purpose
+
+This module is designed to:
+
+- **Enable vocabulary-aware CEL expressions:** Provide CEL functions that compare and group vocabulary codes by URI, supporting local code mappings and concept groups.
+- **Offer semantic helper shortcuts:** Supply human-readable CEL functions like `is_female()` and `is_head()` that map to concept group membership checks.
+- **Cache vocabulary lookups for performance:** Use session-scoped and ORM-level caching to avoid N+1 queries during CEL evaluation.
+
+## Module Dependencies
+
+| Dependency | Purpose |
+| --- | --- |
+| `spp_cel_domain` | Write simple CEL-like expressions to filter records (Open... |
+| `spp_vocabulary` | OpenSPP: Vocabulary |
+
+## Key Features
+
+### Vocabulary Functions
+
+The module registers the following functions for use in CEL expressions:
+
+| Function | Description | Example |
+| --- | --- | --- |
+| `code(identifier)` | Resolve a vocabulary code by URI or alias | `r.gender_id == code("female")` |
+| `code_eq(field, identifier)` | Compare a code field handling local code mappings | `code_eq(r.gender_id, "female")` |
+| `in_group(field, group_name)` | Check if a code belongs to a concept group | `in_group(r.gender_id, "feminine_gender")` |
+
+### Semantic Helpers
+
+Shortcut functions that delegate to `in_group()` with predefined concept group names:
+
+| Function | Concept Group | Example |
+| --- | --- | --- |
+| `is_female(field)` | `feminine_gender` | `is_female(r.gender_id)` |
+| `is_male(field)` | `masculine_gender` | `is_male(r.gender_id)` |
+| `is_head(field)` | `head_of_household` | `is_head(r.relationship_type_id)` |
+| `is_pregnant(field)` | `pregnant_eligible` | `is_pregnant(r.pregnancy_status_id)` |
+| `head(member)` | N/A (checks membership type) | `members.exists(m, head(m))` |
+
+The `head()` function checks whether a member holds the "head" membership type in their group, rather than checking a vocabulary code field.
+
+### Domain Translation
+
+The CEL translator is extended to convert vocabulary functions into Odoo domains:
+
+- `in_group()` and semantic helpers produce `OR` domains checking both `uri` and `reference_uri` fields against the group's code URIs.
+- `code_eq()` and `code()` comparisons resolve identifiers via alias lookup and build URI-based equality domains.
+- Only `==` and `!=` operators are supported for code comparisons.
+
+### Vocabulary Cache
+
+A two-layer caching system optimizes vocabulary lookups:
+
+- **Layer 1 (ORM cache):** Registry-scoped cache in `VocabularyConceptGroup` for group URI sets.
+- **Layer 2 (Session cache):** Per-evaluation `VocabularyCache` instance that provides O(1) frozenset membership checks and avoids redundant lookups within a single CEL evaluation session.
+
+## Integration
+
+- **spp_cel_domain:** Extends the CEL translator to handle vocabulary function calls and the CEL function registry for runtime function resolution. Auto-installs when both dependencies are present.
+- **spp_vocabulary:** Reads from `spp.vocabulary.code` for code resolution and `spp.vocabulary.concept.group` for group membership checks. Ships predefined concept groups via XML data.

--- a/docs/reference/modules/spp_cel_widget.md
+++ b/docs/reference/modules/spp_cel_widget.md
@@ -3,7 +3,7 @@ openspp:
   doc_status: draft
 ---
 
-# CEL Expression Widget
+# Expression Widget
 
 **Module:** `spp_cel_widget`
 
@@ -22,10 +22,10 @@ This module is designed to:
 
 ## Module Dependencies
 
-| Dependency       | Description                                   |
-| ---------------- | --------------------------------------------- |
-| `web`            | Odoo web framework for frontend components    |
-| `spp_cel_domain` | CEL expression parsing and compilation engine |
+| Dependency | Purpose |
+| --- | --- |
+| `web` | Web interface components |
+| `spp_cel_domain` | Write simple CEL-like expressions to filter records (Open... |
 
 ## Key Features
 

--- a/docs/reference/modules/spp_change_request_v2.md
+++ b/docs/reference/modules/spp_change_request_v2.md
@@ -24,16 +24,17 @@ This module is designed to:
 
 ## Module Dependencies
 
-| Module              | Description                                |
-| ------------------- | ------------------------------------------ |
-| **spp_base_common** | Common utilities and base functionality    |
-| **spp_registry**    | Core registry for individuals and groups   |
-| **spp_security**    | Security groups and privileges             |
-| **spp_approval**    | Approval workflow infrastructure           |
-| **spp_event_data**  | Event data integration                     |
-| **spp_dms**         | Document management for attachments        |
-| **spp_vocabulary**  | Controlled vocabularies for document types |
-| **mail**            | Messaging and activity tracking            |
+| Dependency | Purpose |
+| --- | --- |
+| `base` | Odoo core framework |
+| `mail` | Communication and activity tracking |
+| `spp_base_common` | The OpenSPP base module that provides the main menu, gene... |
+| `spp_registry` | Consolidated registry management for individuals, groups,... |
+| `spp_security` | Central security definitions for OpenSPP modules |
+| `spp_approval` | Standardized approval workflows with multi-tier sequencin... |
+| `spp_event_data` | Records and tracks events related to individual and group... |
+| `spp_dms` | The OpenSPP Dms module provides a centralized system for ... |
+| `spp_vocabulary` | OpenSPP: Vocabulary |
 
 ## Key Features
 
@@ -196,3 +197,11 @@ Enhanced user experience features:
 - {doc}`spp_cr_types_base` - Basic change request types
 - {doc}`spp_studio_change_requests` - No-code CR type builder
 - {doc}`spp_approval` - Approval workflow infrastructure
+
+```{toctree}
+:maxdepth: 1
+:hidden:
+
+spp_cr_types_advanced
+spp_cr_types_base
+```

--- a/docs/reference/modules/spp_claim_169.md
+++ b/docs/reference/modules/spp_claim_169.md
@@ -21,25 +21,26 @@ QR Credentials implements the MOSIP Claim 169 specification for generating verif
 - Provides APIs for offline credential verification
 - Supports multiple credential issuers for different programs
 
-## Dependencies
+## Module Dependencies
 
-| Module | Purpose |
-|--------|---------|
+| Dependency | Purpose |
+| --- | --- |
 | `base` | Odoo core framework |
-| `mail` | Communication and notifications |
-| `spp_security` | Security groups and access control |
-| `spp_registry` | Registrant data source |
-| `spp_key_management` | Cryptographic key storage |
-| `spp_audit` | Audit trail for credential operations |
-| `spp_cel_domain` | CEL expressions for transformations |
+| `mail` | Communication and activity tracking |
+| `spp_security` | Central security definitions for OpenSPP modules |
+| `spp_registry` | Consolidated registry management for individuals, groups,... |
+| `spp_key_management` | Centralized cryptographic key management with pluggable p... |
+| `spp_audit` | Comprehensively tracks all data modifications and user ac... |
+| `spp_cel_domain` | Write simple CEL-like expressions to filter records (Open... |
 
-### External Python Packages
+### External Dependencies
 
 | Package | Purpose |
-|---------|---------|
-| `qrcode` | QR code generation |
-| `Pillow` | Image processing |
-| `claim169` | Claim 169 encoding/decoding |
+| --- | --- |
+| `qrcode` | |
+| `Pillow` | |
+| `claim169` | |
+| `jwcrypto` | |
 
 ## Claim 169 Attribute Specification
 
@@ -144,13 +145,3 @@ Go to **Claim 169 > Credentials** to:
 - Download CWT data
 - Check expiration status
 - Revoke credentials
-
-## Technical Details
-
-| Property | Value |
-|----------|-------|
-| Technical Name | `spp_claim_169` |
-| Category | OpenSPP/Identity |
-| Version | 19.0.1.1.0 |
-| License | LGPL-3 |
-| Development Status | Beta |

--- a/docs/reference/modules/spp_consent.md
+++ b/docs/reference/modules/spp_consent.md
@@ -31,12 +31,12 @@ Use this module when your program needs to:
 
 ## Module Dependencies
 
-| Dependency     | Purpose                              |
-| -------------- | ------------------------------------ |
-| `base`         | Odoo core framework                  |
-| `mail`         | Communication and activity tracking  |
-| `spp_registry` | Registrant data for consent subjects |
-| `spp_security` | Security groups and access control   |
+| Dependency | Purpose |
+| --- | --- |
+| `base` | Odoo core framework |
+| `mail` | Communication and activity tracking |
+| `spp_registry` | Consolidated registry management for individuals, groups,... |
+| `spp_security` | Central security definitions for OpenSPP modules |
 
 ## Key Features
 
@@ -134,16 +134,6 @@ Follows the three-tier access control pattern:
 | Viewer  | Read-only access to consent records        |
 | Officer | Create and modify consent records          |
 | Manager | Full CRUD including taxonomy configuration |
-
-## Technical Details
-
-| Property       | Value         |
-| -------------- | ------------- |
-| Technical Name | `spp_consent` |
-| Category       | OpenSPP       |
-| Version        | 19.0.2.0.0    |
-| License        | LGPL-3        |
-| Application    | No            |
 
 ## Integration
 

--- a/docs/reference/modules/spp_cr_types_advanced.md
+++ b/docs/reference/modules/spp_cr_types_advanced.md
@@ -3,7 +3,7 @@ openspp:
   doc_status: draft
 ---
 
-# CR Types - Advanced
+# Advanced Types
 
 **Module:** `spp_cr_types_advanced`
 
@@ -19,8 +19,8 @@ These types have `is_studio_editable=False` by design. If you need to modify the
 ## Module Dependencies
 
 | Dependency | Purpose |
-|------------|---------|
-| `spp_change_request_v2` | Base change request infrastructure |
+| --- | --- |
+| `spp_change_request_v2` | Configuration-driven change request system with UX improv... |
 
 ## Available Change Request Types
 
@@ -210,7 +210,6 @@ To modify the behavior of an advanced type, create a custom module that inherits
 
 from odoo import models
 
-
 class CustomAddMember(models.Model):
     _inherit = "spp.cr.apply.add_member"
 
@@ -224,13 +223,3 @@ class CustomAddMember(models.Model):
 
         return result
 ```
-
-## Technical Details
-
-| Property | Value |
-|----------|-------|
-| Technical Name | `spp_cr_types_advanced` |
-| Category | OpenSPP |
-| Version | 19.0.1.0.0 |
-| License | LGPL-3 |
-| Development Status | Beta |

--- a/docs/reference/modules/spp_cr_types_base.md
+++ b/docs/reference/modules/spp_cr_types_base.md
@@ -3,7 +3,7 @@ openspp:
   doc_status: draft
 ---
 
-# CR Types - Base
+# Base Types
 
 **Module:** `spp_cr_types_base`
 
@@ -22,9 +22,9 @@ This module is designed to:
 
 ## Module Dependencies
 
-| Module                    | Description                                  |
-| ------------------------- | -------------------------------------------- |
-| **spp_change_request_v2** | Change request infrastructure and processing |
+| Dependency | Purpose |
+| --- | --- |
+| `spp_change_request_v2` | Configuration-driven change request system with UX improv... |
 
 ## Included Change Request Types
 

--- a/docs/reference/modules/spp_custom_field.md
+++ b/docs/reference/modules/spp_custom_field.md
@@ -22,11 +22,11 @@ This module is designed to:
 
 ## Module Dependencies
 
-| Module           | Description                              |
-| ---------------- | ---------------------------------------- |
-| **base**         | Odoo core functionality                  |
-| **spp_registry** | Core registry for individuals and groups |
-| **spp_security** | Security group management                |
+| Dependency | Purpose |
+| --- | --- |
+| `base` | Odoo core framework |
+| `spp_registry` | Consolidated registry management for individuals, groups,... |
+| `spp_security` | Central security definitions for OpenSPP modules |
 
 ## Key Features
 

--- a/docs/reference/modules/spp_dci.md
+++ b/docs/reference/modules/spp_dci.md
@@ -1,0 +1,111 @@
+---
+openspp:
+  doc_status: draft
+---
+
+# DCI Core
+
+**Module:** `spp_dci`
+
+## Overview
+
+Core DCI (Digital Convergence Initiative) API components
+
+## Purpose
+
+This module is designed to:
+
+- **Provide DCI-compliant data schemas:** Define Pydantic models for all Digital Convergence Initiative (DCI/SPDCI) message types including search, subscription, receipts, and notifications.
+- **Manage cryptographic signing keys:** Generate, activate, and revoke Ed25519 and RSA-256 keypairs for DCI message authentication.
+- **Support message signing and verification:** Implement HTTP Signature signing and verification following the draft-cavage specification.
+
+## Module Dependencies
+
+| Dependency | Purpose |
+| --- | --- |
+| `base` | Odoo core framework |
+| `spp_registry` | Consolidated registry management for individuals, groups,... |
+
+### External Dependencies
+
+| Package | Purpose |
+| --- | --- |
+| `pydantic` | Schema validation for DCI message types |
+| `cryptography` | Key generation, signing, and verification (Ed25519, RSA) |
+
+## Key Features
+
+### DCI Message Schemas
+
+Pydantic schemas implementing the SPDCI API standard:
+
+| Schema Group | Models | Description |
+| --- | --- | --- |
+| Envelope | `DCIEnvelope`, `DCIMessageHeader`, `DCICallbackHeader` | Three-part message structure (signature, header, message) |
+| Person | `Person`, `Name`, `DisabilityInfo`, `RelatedPerson` | Individual person entity with identifiers and demographics |
+| Group | `Group`, `Member` | Household/family unit with member list |
+| Search | `SearchRequest`, `SearchResponse`, `SearchCriteria` | Registry search with pagination and expression queries |
+| Subscription | `SubscribeRequest`, `SubscribeResponse`, `UnsubscribeRequest` | Event subscription management |
+| Receipt | `ReceiptRequest`, `ReceiptResponse` | Delivery confirmation for async notifications |
+| Common | `Identifier`, `Address`, `GeoCoordinates`, `Place` | Shared types across all message schemas |
+
+### Constants and Enumerations
+
+The module defines SPDCI-compliant enumerations:
+
+| Enum | Values |
+| --- | --- |
+| `RegistryType` | Social Registry, CRVS, IBR, Disability Registry, Functional Registry |
+| `QueryType` | idtype-value, expression, predicate, graphql |
+| `RequestStatus` | rcvd, pdng, succ, rjct |
+| `SexCategory` | male, female, other, unknown (ISO 5218) |
+| `IdentifierType` | UIN, BRN, MRN, DRN |
+
+### Signing Key Management
+
+The `spp.dci.signing.key` model manages cryptographic keys with a lifecycle:
+
+| State | Description |
+| --- | --- |
+| `draft` | Key record created, keypair not yet generated |
+| `active` | Key is available for signing messages |
+| `revoked` | Key is permanently disabled |
+
+Key features:
+- Supports Ed25519 and RSA-256 algorithms
+- Generates PEM-encoded keypairs
+- Produces JWKS entries for the `/.well-known/jwks.json` endpoint
+- Private keys restricted to system admin group
+
+### Message Signing
+
+The `DCISigner` class creates HTTP Signatures per the draft-cavage specification:
+- Computes SHA-256 digest of header and message
+- Signs with Ed25519 private key
+- Produces a signature string with created/expires timestamps (5-minute validity)
+
+The `DCIVerifier` class validates signatures by parsing the header, checking expiration, recomputing the digest, and verifying the cryptographic signature.
+
+### Response Helpers
+
+Utility functions for building DCI server responses:
+- `build_signed_envelope()` constructs and signs a complete DCI response envelope
+- `build_error_search_response_item()` creates properly coded rejection responses
+- `get_response_action()` maps request actions to SPDCI response actions
+
+## Integration
+
+- **spp_registry:** DCI schemas map to OpenSPP registry entities (individuals as Person, groups as Group with Member lists).
+- **Downstream modules:** The schemas and signing infrastructure are consumed by `spp_dci_server` (API endpoints) and `spp_dci_client` (outbound DCI queries).
+
+```{toctree}
+:maxdepth: 1
+:hidden:
+
+spp_dci_client
+spp_dci_client_crvs
+spp_dci_client_dr
+spp_dci_client_ibr
+spp_dci_demo
+spp_dci_server
+```

--- a/docs/reference/modules/spp_dci_client.md
+++ b/docs/reference/modules/spp_dci_client.md
@@ -3,7 +3,7 @@ openspp:
   doc_status: draft
 ---
 
-# DCI Client
+# Client
 
 **Module:** `spp_dci_client`
 
@@ -32,18 +32,18 @@ This is a foundation module. Install specialized client modules for specific reg
 | Application | No |
 | Status | Alpha |
 
-### Dependencies
+### Module Dependencies
 
-| Module | Purpose |
-|--------|---------|
+| Dependency | Purpose |
+| --- | --- |
 | `base` | Odoo core framework |
-| `spp_dci` | DCI standards and schemas |
+| `spp_dci` | Core DCI (Digital Convergence Initiative) API components |
 
-### External Python Dependencies
+### External Dependencies
 
 | Package | Purpose |
-|---------|---------|
-| `httpx` | Async HTTP client for API calls |
+| --- | --- |
+| `httpx` | |
 
 ## Data Models
 

--- a/docs/reference/modules/spp_dci_client_crvs.md
+++ b/docs/reference/modules/spp_dci_client_crvs.md
@@ -3,7 +3,7 @@ openspp:
   doc_status: draft
 ---
 
-# DCI Client - CRVS
+# Client - CRVS
 
 **Module:** `spp_dci_client_crvs`
 
@@ -24,12 +24,12 @@ Use this module if you need to:
 
 If you only need basic registry management without external CRVS integration, see {doc}`spp_registry` instead.
 
-## Dependencies
+## Module Dependencies
 
-| Module | Purpose |
-|--------|---------|
-| `spp_dci_client` | Base DCI client infrastructure |
-| `spp_registry` | Registrant data for matching and updates |
+| Dependency | Purpose |
+| --- | --- |
+| `spp_dci_client` | Base DCI client infrastructure with OAuth2 and data sourc... |
+| `spp_registry` | Consolidated registry management for individuals, groups,... |
 
 ## Key Features
 
@@ -173,13 +173,3 @@ failed_events = env["spp.dci.crvs.event"].search([("state", "=", "error")])
 # Retry processing
 failed_events.action_retry_processing()
 ```
-
-## Technical Details
-
-| Property | Value |
-|----------|-------|
-| Technical Name | `spp_dci_client_crvs` |
-| Category | OpenSPP/Integration |
-| Version | 19.0.1.0.0 |
-| License | LGPL-3 |
-| Development Status | Alpha |

--- a/docs/reference/modules/spp_dci_client_dr.md
+++ b/docs/reference/modules/spp_dci_client_dr.md
@@ -3,7 +3,7 @@ openspp:
   doc_status: draft
 ---
 
-# DCI Client - Disability Registry
+# Client - Disability
 
 **Module:** `spp_dci_client_dr`
 
@@ -23,10 +23,10 @@ Use this module when your program needs to:
 ## Module Dependencies
 
 | Dependency | Purpose |
-|------------|---------|
-| `spp_dci_client` | Base DCI client infrastructure |
-| `spp_dci_server` | DCI server for bidirectional exchange |
-| `spp_registry` | Registrant data for updates |
+| --- | --- |
+| `spp_dci_client` | Base DCI client infrastructure with OAuth2 and data sourc... |
+| `spp_dci_server` | DCI API server infrastructure with FastAPI routers |
+| `spp_registry` | Consolidated registry management for individuals, groups,... |
 
 ## Data Models
 
@@ -125,14 +125,3 @@ Disability data supports program targeting:
 - Eligibility criteria can include disability status
 - Benefit amounts may vary by disability severity
 - Special assistance flags for service delivery
-
-## Technical Details
-
-| Property | Value |
-|----------|-------|
-| Technical Name | `spp_dci_client_dr` |
-| Category | OpenSPP/Integration |
-| Version | 19.0.1.0.0 |
-| License | LGPL-3 |
-| Application | No |
-| Development Status | Alpha |

--- a/docs/reference/modules/spp_dci_client_ibr.md
+++ b/docs/reference/modules/spp_dci_client_ibr.md
@@ -3,7 +3,7 @@ openspp:
   doc_status: draft
 ---
 
-# DCI Client - IBR
+# Client - IBR
 
 **Module:** `spp_dci_client_ibr`
 
@@ -22,11 +22,11 @@ Use this module when you need to:
 
 ## Module Dependencies
 
-| Dependency       | Purpose                                      |
-| ---------------- | -------------------------------------------- |
-| `spp_dci_client` | Base DCI client infrastructure and API layer |
-| `spp_dci_server` | DCI server for bidirectional data exchange   |
-| `spp_registry`   | Registrant data and identifier management    |
+| Dependency | Purpose |
+| --- | --- |
+| `spp_dci_client` | Base DCI client infrastructure with OAuth2 and data sourc... |
+| `spp_dci_server` | DCI API server infrastructure with FastAPI routers |
+| `spp_registry` | Consolidated registry management for individuals, groups,... |
 
 ## Data Models
 
@@ -148,14 +148,3 @@ if status["enrolled"]:
 | `no_match`       | No duplicates found in the IBR                   |
 | `possible_match` | Potential match found, requires manual review    |
 | `confirmed_match`| Confirmed duplicate exists in another program    |
-
-## Technical Details
-
-| Property       | Value                |
-| -------------- | -------------------- |
-| Technical Name | `spp_dci_client_ibr` |
-| Category       | OpenSPP/Integration  |
-| Version        | 19.0.1.0.0           |
-| License        | LGPL-3               |
-| Application    | No                   |
-| Status         | Alpha                |

--- a/docs/reference/modules/spp_dci_demo.md
+++ b/docs/reference/modules/spp_dci_demo.md
@@ -1,0 +1,88 @@
+---
+openspp:
+  doc_status: draft
+---
+
+# Demo
+
+**Module:** `spp_dci_demo`
+
+## Overview
+
+DCI Demo: Birth Verification for Child Benefit Enrollment
+
+## Purpose
+
+This module is designed to:
+
+- **Demonstrate DCI birth verification:** Add birth verification via DCI to the "Add Member" change request workflow, querying a CRVS registry (e.g., OpenCRVS) to verify birth registration numbers.
+- **Auto-create verified registry IDs:** When a birth is verified, automatically create a BRN registry ID on the new individual with verification metadata.
+- **Auto-enroll in programs:** After a member is added and verified, automatically enroll the household and its members in a configured program.
+
+## Module Dependencies
+
+| Dependency | Purpose |
+| --- | --- |
+| `spp_mis_demo_v2` | Demo Generator V2 for SP-MIS programs with fixed stories ... |
+| `spp_dci_client` | Base DCI client infrastructure with OAuth2 and data sourc... |
+| `spp_change_request_v2` | Configuration-driven change request system with UX improv... |
+| `spp_programs` | Manage cash and in-kind entitlements, integrate with inve... |
+
+## Key Features
+
+### Birth Verification on Change Requests
+
+Extends the "Add Member" change request detail (`spp.cr.detail.add_member`) with birth verification fields:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `birth_registration_number` | Char | BRN entered by the social worker |
+| `birth_verification_status` | Selection | unverified, verified, not_found, or error |
+| `dci_data_match` | Boolean | Whether DCI response data matches CR fields |
+| `birth_verification_date` | Datetime | When verification was performed |
+| `birth_verification_response` | Text | Raw JSON response for audit |
+| `dci_data_source_id` | Many2one | CRVS data source to verify against |
+
+A "Verify Birth" button triggers a DCI search by BRN against the configured CRVS registry. Editing verified fields (name, DOB, gender, BRN) automatically invalidates the verification.
+
+### Data Match Verification
+
+After a successful DCI lookup, the module compares the returned person data against the change request fields:
+
+- Given name (case-insensitive)
+- Family name (case-insensitive)
+- Birth date
+- Gender/sex
+
+Mismatches are logged and flagged for manual review.
+
+### Change Request Reviewer UX
+
+The main change request form (`spp.change.request`) is extended with computed DCI verification fields:
+
+| Field | Description |
+| --- | --- |
+| `dci_verification_status` | Pulled from the detail record's birth verification status |
+| `dci_verification_html` | HTML summary with status badge, BRN, and match indicator |
+| `dci_data_match` | Whether the DCI data matches |
+
+### Verified BRN Registry ID
+
+When the change request is applied and the birth was verified, a `spp.registry.id` record is created on the new individual with:
+
+- The BRN as the identifier value
+- Status set to `valid`
+- Verification method set to `dci_api`
+- Verification source from the data source name
+- Raw verification response stored for audit
+
+### Auto-Enrollment
+
+After applying the change request, if a program is configured via the `spp_dci_demo.enrollment_program_id` system parameter, the household and all its members (including the newly added child) are automatically enrolled.
+
+## Integration
+
+- **spp_dci_client:** Uses `DCIClient` to perform DCI search queries against configured CRVS data sources.
+- **spp_change_request_v2:** Extends `spp.cr.detail.add_member` with verification fields and `spp.cr.apply.add_member` with post-apply logic for BRN creation and auto-enrollment.
+- **spp_programs:** Creates `spp.program.membership` records for auto-enrollment of households and members.
+- **spp_mis_demo_v2:** Depends on demo data for the target enrollment program (Conditional Child Grant).

--- a/docs/reference/modules/spp_dci_server.md
+++ b/docs/reference/modules/spp_dci_server.md
@@ -3,7 +3,7 @@ openspp:
   doc_status: draft
 ---
 
-# DCI Server
+# Server
 
 **Module:** `spp_dci_server`
 
@@ -23,24 +23,13 @@ Use this module when you need to:
 ## Module Dependencies
 
 | Dependency | Purpose |
-|------------|---------|
+| --- | --- |
 | `base` | Odoo core framework |
-| `fastapi` | FastAPI framework for API endpoints |
-| `queue_job` | Background job processing |
-| `spp_dci` | DCI standards and schemas |
-| `spp_dci_client` | Shared DCI infrastructure |
-| `spp_api_v2` | API V2 framework |
-
-## Technical Details
-
-| Property | Value |
-|----------|-------|
-| Technical Name | `spp_dci_server` |
-| Category | OpenSPP/Integration |
-| Version | 19.0.1.0.0 |
-| License | LGPL-3 |
-| Application | No |
-| Status | Alpha |
+| `fastapi` | FastAPI integration for Odoo |
+| `job_worker` | Background job worker |
+| `spp_dci` | Core DCI (Digital Convergence Initiative) API components |
+| `spp_dci_client` | Base DCI client infrastructure with OAuth2 and data sourc... |
+| `spp_api_v2` | OpenSPP API V2 - Standards-aligned, consent-respecting AP... |
 
 ## Data Models
 

--- a/docs/reference/modules/spp_demo.md
+++ b/docs/reference/modules/spp_demo.md
@@ -22,20 +22,21 @@ This module is designed to:
 
 ## Module Dependencies
 
-| Dependency          | Description                                         |
-| ------------------- | --------------------------------------------------- |
-| **base**            | Odoo core functionality                             |
-| **spp_base_common** | OpenSPP common utilities                            |
-| **spp_registry**    | Registry for individuals and groups                 |
-| **spp_vocabulary**  | Standardized code lists                             |
-| **queue_job**       | Background job processing for large data generation |
-| **spp_security**    | Security groups for demo users                      |
+| Dependency | Purpose |
+| --- | --- |
+| `base` | Odoo core framework |
+| `spp_base_common` | The OpenSPP base module that provides the main menu, gene... |
+| `spp_registry` | Consolidated registry management for individuals, groups,... |
+| `spp_vocabulary` | OpenSPP: Vocabulary |
+| `job_worker` | Background job worker |
+| `spp_security` | Central security definitions for OpenSPP modules |
+| `spp_area` | Establishes direct associations between OpenSPP registran... |
 
-### External Python Dependencies
+### External Dependencies
 
-| Package   | Description                       |
-| --------- | --------------------------------- |
-| **faker** | Generates fake but realistic data |
+| Package | Purpose |
+| --- | --- |
+| `faker` | |
 
 ## Key Features
 

--- a/docs/reference/modules/spp_disability_registry.md
+++ b/docs/reference/modules/spp_disability_registry.md
@@ -1,0 +1,76 @@
+---
+openspp:
+  doc_status: draft
+---
+
+# Disability Registry
+
+**Module:** `spp_disability_registry`
+
+## Overview
+
+Disability assessment and registry management for social protection
+
+## Purpose
+
+This module is designed to:
+
+- **Assess disability status:** Record structured disability assessments using the Washington Group Short Set (WG-SS) for adults and the Child Functioning Module (CFM) for children, with automatic age-based assessment type selection.
+- **Track assistive devices:** Manage assistive device needs, requests, and provisions for registrants with disabilities.
+- **Compute disability indicators:** Automatically determine disability status based on WG standard thresholds (any domain with "a lot of difficulty" or "cannot do at all").
+- **Schedule reassessments:** Set review categories (improvement expected, possible, or not expected) that compute next review dates automatically.
+- **Provide CEL functions:** Register disability-related functions for use in program eligibility and entitlement calculations.
+
+## Module Dependencies
+
+| Dependency | Purpose |
+| --- | --- |
+| `spp_registry` | Consolidated registry management for individuals, groups,... |
+| `spp_vocabulary` | OpenSPP: Vocabulary |
+| `spp_approval` | Standardized approval workflows with multi-tier sequencin... |
+| `spp_cel_domain` | Write simple CEL-like expressions to filter records (Open... |
+
+## Key Features
+
+### Disability Assessments
+
+The assessment model (`spp.disability.assessment`) captures structured disability data with approval workflows.
+
+| Field | Description |
+| --- | --- |
+| Assessment Type | Automatically computed from age: WG-SS (18+), CFM 5-17, CFM 2-4 |
+| WG-SS Domains | Six domains: seeing, hearing, walking, remembering, self-care, communicating |
+| Difficulty Levels | None, Some difficulty, A lot of difficulty, Cannot do at all |
+| Impairment Classification | Type, cause, and severity using DCI-aligned vocabulary codes |
+| Review Category | Improvement Expected (12 mo), Possible (3 yr), Not Expected (6 yr) |
+| Proxy Response | Tracks whether responses were provided by a proxy and the relationship |
+
+### Computed Disability Status
+
+- `has_disability` is set to `True` when any WG domain has "a lot of difficulty" or "cannot do at all"
+- `wg_domain_count` counts the number of domains with severe difficulty
+- The latest approved assessment automatically becomes the registrant's current assessment
+
+### Assistive Devices
+
+Tracks assistive devices (`spp.assistive.device`) linked to registrants with vocabulary-based device types and a status workflow: Needed, Requested, Provided. An `has_unmet_device_need` flag on the registrant indicates outstanding needs.
+
+### CEL Functions for Eligibility
+
+The module registers six CEL functions for use in program eligibility rules:
+
+| Function | Description |
+| --- | --- |
+| `has_disability(r)` | Check if registrant has approved disability status |
+| `disability_severity(r)` | Get the disability severity vocabulary code |
+| `is_severe_disability(r)` | Check for severe or profound disability (uses concept groups) |
+| `household_has_pwd(r)` | Check if any active household member has a disability |
+| `household_pwd_count(r)` | Count household members with disability |
+| `needs_reassessment(r)` | Check if next review date is past or today |
+
+## Integration
+
+- **spp_registry:** Extends `res.partner` with disability assessment history, current status fields, and assistive device tracking on individual registrants.
+- **spp_approval:** Assessments use the approval mixin for multi-tier review before becoming the registrant's current assessment.
+- **spp_vocabulary:** Impairment types, causes, severity levels, and device types are defined as vocabulary codes with DCI-aligned namespace URIs.
+- **spp_cel_domain:** Registers disability CEL functions for building eligibility expressions in programs.

--- a/docs/reference/modules/spp_dms.md
+++ b/docs/reference/modules/spp_dms.md
@@ -22,17 +22,17 @@ This module is designed to:
 
 ## Module Dependencies
 
-| Dependency       | Description                |
-| ---------------- | -------------------------- |
-| **base**         | Core Odoo framework        |
-| **web**          | Web client assets          |
-| **spp_security** | OpenSPP security framework |
+| Dependency | Purpose |
+| --- | --- |
+| `base` | Odoo core framework |
+| `web` | Web interface components |
+| `spp_security` | Central security definitions for OpenSPP modules |
 
-### External Python Dependencies
+### External Dependencies
 
-| Package    | Description                               |
-| ---------- | ----------------------------------------- |
-| **Pillow** | Image processing for thumbnails (>=9.0.1) |
+| Package | Purpose |
+| --- | --- |
+| `Pillow>=9.0.1` | |
 
 ## Key Features
 
@@ -182,21 +182,3 @@ The restore process:
 1. Open the file record
 2. Click "Enable Versioning"
 3. Initial version is created automatically
-
-## Technical Details
-
-### Checksum Computation
-
-Files use SHA-512 checksums for:
-
-- Data integrity verification
-- Duplicate detection
-- Version comparison
-
-### Concurrent Version Handling
-
-Version creation uses atomic SQL operations with retry logic to handle race conditions when multiple users modify the same file.
-
-### Storage
-
-File content is stored as Odoo attachments (`content_file` field), allowing standard Odoo file storage configuration (database or filestore).

--- a/docs/reference/modules/spp_drims.md
+++ b/docs/reference/modules/spp_drims.md
@@ -1,0 +1,136 @@
+---
+openspp:
+  doc_status: draft
+---
+
+# DRIMS - Disaster Response Inventory Management
+
+**Module:** `spp_drims`
+
+## Overview
+
+Disaster relief inventory management for donations, requests, and distribution tracking. Links to hazard incidents with multi-tier approval workflows and warehouse operations.
+
+## Purpose
+
+This module is designed to:
+
+- **Track donations:** Record in-kind donations linked to hazard incidents with a state machine (announced, received, inspected, stocked) and state transition validation.
+- **Manage relief requests:** Submit, approve, allocate, and dispatch supply requests with FIFO stock allocation, SLA tracking, and fulfillment progress monitoring.
+- **Coordinate warehouse operations:** Extend Odoo stock warehouses with DRIMS-specific fields for disaster relief, including incident linkage, GIS location, coverage areas, and stock health indicators.
+- **Monitor alerts:** Automated scheduled checks for low stock, expiring inventory, and SLA breaches with urgency-based styling and team assignment.
+- **Track returns:** Manage returned items from distribution points with condition tracking, disposition decisions (restock, repair, dispose), and restocking workflows.
+- **Deploy personnel:** Track field staff, volunteers, and team members deployed across areas with roles, organizations, and cluster assignments.
+
+## Module Dependencies
+
+| Dependency | Purpose |
+| --- | --- |
+| `base` | Odoo core framework |
+| `mail` | Communication and activity tracking |
+| `stock` | Inventory and warehouse management |
+| `spp_alerts` | Generic alert engine for threshold monitoring, expiry tra... |
+| `spp_security` | Central security definitions for OpenSPP modules |
+| `spp_vocabulary` | OpenSPP: Vocabulary |
+| `spp_area` | Establishes direct associations between OpenSPP registran... |
+| `spp_hazard` | Provides hazard classification, incident recording, and i... |
+| `spp_gis` | GIS core plus area geo fields and importer extensions (po... |
+| `spp_gis_report` | Geographic visualization and reporting for social protect... |
+| `spp_service_points` | The OpenSPP Service Points module manages physical or vir... |
+| `spp_approval` | Standardized approval workflows with multi-tier sequencin... |
+| `spp_cel_domain` | Write simple CEL-like expressions to filter records (Open... |
+| `spp_audit` | Comprehensively tracks all data modifications and user ac... |
+| `job_worker` | Background job worker |
+
+## Key Features
+
+### Donation Management
+
+Donations (`spp.drims.donation`) follow a strict state machine with validated transitions:
+
+| State | Description |
+| --- | --- |
+| Announced | Donation pledged by donor |
+| Received | Items physically received at warehouse, stock picking created |
+| Inspected | Quality inspection completed (via inspection wizard with condition/disposition per item) |
+| Stocked | Items put away into warehouse inventory, stock picking validated |
+| Cancelled / Rejected | Terminal states, pending pickings are cancelled |
+
+Donations track donor type, restrictions, and line items with pledged vs. received quantities.
+
+### Request Workflow
+
+Requests (`spp.drims.request`) go through approval and fulfillment stages:
+
+- **Submission:** Validates request has items, triggers approval workflow
+- **Approval:** Multi-tier approval via `spp_approval` mixin, with reject and request-revision actions
+- **Allocation:** FIFO stock allocation with preview wizard showing availability before committing
+- **Dispatch:** Creates outgoing stock pickings with move lines per allocated item
+- **Fulfillment tracking:** Computes allocation %, fulfillment %, and quantity progress per line
+
+### SLA Monitoring
+
+Requests include configurable SLA tracking based on priority level:
+
+| Priority | Default SLA Hours |
+| --- | --- |
+| Critical | 4 |
+| High | 8 |
+| Routine | 24 |
+| Low | 48 |
+
+SLA status (on time, warning, breached) is computed and stored for dashboard filtering. Thresholds are configurable via system parameters.
+
+### Alert Engine
+
+The DRIMS alert model (`spp.drims.alert`) extends the base alert system with scheduled cron jobs:
+
+| Alert Type | Trigger |
+| --- | --- |
+| Low Stock | Available stock falls below 50% of needed quantity |
+| Expiry | Lot expiration date within 30 days (requires `product_expiry`) |
+| SLA Breach | Request past its needed date and not delivered |
+| SLA Warning | Request within 2 days of deadline and not dispatched |
+
+Alerts include urgency states (overdue, urgent, soon, normal), team assignment, and navigation links to related records.
+
+### Request Templates
+
+Reusable templates (`spp.drims.request.template`) allow creating pre-configured request item lists. Templates can be personal or shared across users, and a wizard enables creating requests from templates with incident and area selection.
+
+### Incident Dashboard KPIs
+
+The module extends hazard incidents with computed KPIs using a hybrid caching strategy via `spp.data.value`:
+
+| KPI | Description |
+| --- | --- |
+| Donation count / value | Total donations and their monetary value |
+| Request count / pending | Total and pending approval requests |
+| Stock value / units / items | Current warehouse inventory metrics |
+| Distributed value | Value of completed dispatch pickings |
+| Beneficiaries served | Count from completed dispatches in last 30 days |
+| Active / critical alerts | Alert counts by state and priority |
+| Return count / value | Item returns and their value |
+
+### Personnel Tracking
+
+Deployed personnel (`spp.drims.personnel`) are tracked with deployment area, organization, role, cluster assignment, and status (deployed, standby, on leave, returned). Days deployed is computed automatically.
+
+## Integration
+
+- **stock:** Creates incoming pickings for donation receipts, outgoing pickings for request dispatches, and incoming pickings for returns. Extends `stock.warehouse` with DRIMS configuration fields.
+- **spp_hazard:** Extends `spp.hazard.incident` with donation/request/alert/return KPIs, warehouse linkage, coordination modes, and alert threshold overrides.
+- **spp_approval:** Requests use the approval mixin for multi-tier approval workflows with configurable approval definitions.
+- **spp_alerts:** DRIMS alerts inherit from `spp.alert` and add incident, warehouse, product, and request context.
+- **spp_gis / spp_gis_report:** Warehouses have GIS point locations; GIS reports support DRIMS request and incident area data sources.
+- **spp_vocabulary:** All states, types, priorities, donor types, and other classifiers are vocabulary-driven for extensibility.
+- **spp_audit:** Audit rules track changes to DRIMS records.
+- **spp_service_points:** Requests can specify service points as distribution locations.
+
+```{toctree}
+:maxdepth: 1
+:hidden:
+
+spp_drims_sl
+spp_drims_sl_demo
+```

--- a/docs/reference/modules/spp_drims_sl.md
+++ b/docs/reference/modules/spp_drims_sl.md
@@ -1,0 +1,62 @@
+---
+openspp:
+  doc_status: draft
+---
+
+# Sri Lanka Configuration
+
+**Module:** `spp_drims_sl`
+
+## Overview
+
+Sri Lanka-specific configuration for DRIMS disaster response inventory management. Includes geographic hierarchy, government agencies, and approval thresholds per DMC requirements.
+
+## Purpose
+
+This module is designed to:
+
+- **Configure Sri Lanka geography:** Define area types for the Sri Lankan administrative hierarchy (Province, District, DS Division, GN Division) and provide the official admin boundary Excel data file.
+- **Set up government agencies:** Pre-configure DMC, NDRRMC, and humanitarian organizations (UNICEF, WFP, Red Cross, CARE, Oxfam) as system partners.
+- **Establish warehouse network:** Create DRIMS warehouses for each province and a central national warehouse.
+- **Configure approval workflows:** Set up multi-tier approval definitions with DMC-specific thresholds and demo users for each approval tier.
+- **Provide product catalog:** Define standard relief product categories and products used in Sri Lanka disaster response.
+
+## Module Dependencies
+
+| Dependency | Purpose |
+| --- | --- |
+| `spp_drims` | Disaster relief inventory management for donations, reque... |
+| `spp_approval` | Standardized approval workflows with multi-tier sequencin... |
+| `product_expiry` | Product expiry date tracking |
+
+## Key Features
+
+### Area Types
+
+Defines Sri Lanka-specific area types mapped to administrative levels:
+
+| Level | Area Type |
+| --- | --- |
+| 0 | Province |
+| 1 | District |
+| 2 | DS Division |
+| 3 | GN Division |
+
+### Master Data
+
+The module installs via XML data files:
+
+- **Company configuration:** Sets the main company to Sri Lanka locale
+- **Hazard categories:** Flood, geological (landslide), drought, and other categories relevant to Sri Lanka
+- **Vocabulary codes:** Sri Lanka-specific vocabulary entries for DRIMS operations
+- **Agencies:** Pre-configured humanitarian organizations as system partners
+- **Warehouses:** Central warehouse in Colombo, national reserve in Anuradhapura, and provincial warehouses across all nine provinces
+- **Product catalog:** Standard relief items with categories (food, non-food, medical, shelter)
+- **Demo users:** Users for each DRIMS role (admin, warehouse manager, approver, officer, viewer)
+- **Approval configuration:** Multi-tier approval workflow with national and provincial approval tiers
+
+## Integration
+
+- **spp_drims:** Provides the base DRIMS framework that this module configures with Sri Lanka-specific data.
+- **spp_approval:** Configures multi-tier approval definitions with DMC-specific thresholds and tier assignments.
+- **product_expiry:** Enables lot-level expiry tracking for perishable relief items.

--- a/docs/reference/modules/spp_drims_sl_demo.md
+++ b/docs/reference/modules/spp_drims_sl_demo.md
@@ -1,0 +1,67 @@
+---
+openspp:
+  doc_status: draft
+---
+
+# Sri Lanka Demo
+
+**Module:** `spp_drims_sl_demo`
+
+## Overview
+
+Demo data generator for DRIMS Sri Lanka implementation. Creates sample incidents, donations, requests, and stock for demonstrations.
+
+## Purpose
+
+This module is designed to:
+
+- **Generate demo incidents:** Create realistic disaster scenarios (monsoon floods, landslides, drought) with affected areas, per-area severity, and coordination modes.
+- **Populate demo donations:** Generate donations from UN agencies and NGOs at various workflow stages (announced through stocked), including lot creation for tracked products.
+- **Create demo requests:** Generate supply requests at different states (draft, pending, approved, rejected) with some intentionally overdue for SLA alert demonstration.
+- **Populate warehouse stock:** Add initial inventory to all DRIMS warehouses with storable products, lot tracking, and some near-expiry lots for alert demos.
+- **Import geographic data:** Import Sri Lanka areas from the official admin boundary Excel file and HDX polygon boundaries for choropleth visualization.
+
+## Module Dependencies
+
+| Dependency | Purpose |
+| --- | --- |
+| `spp_drims_sl` | Sri Lanka-specific configuration for DRIMS disaster respo... |
+| `spp_area_hdx` | HDX Common Operational Datasets (COD) integration for dow... |
+| `spp_gis_report` | Geographic visualization and reporting for social protect... |
+
+### External Dependencies
+
+| Package | Purpose |
+| --- | --- |
+| `faker` | |
+
+## Key Features
+
+### Demo Generator Wizard
+
+A transient model (`spp.drims.demo.generator`) provides a wizard with configurable demo modes:
+
+| Mode | Incidents | Donations/Incident | Requests/Incident | Personnel/Incident |
+| --- | --- | --- | --- | --- |
+| Quick | 1 | 3 | 5 | 5 |
+| Standard | 2 | 5 | 10 | 8 |
+| Full | 3 | 8 | 15 | 15 |
+
+### Generated Data
+
+- **Incidents:** Based on realistic Sri Lanka disaster scenarios with multi-area severity and coordination modes (lead agency, cluster, consortium)
+- **Donations:** Random donor selection from configured agencies, progressed through the donation workflow to target states
+- **Requests:** Include overdue requests for SLA breach demonstration, at-risk requests for SLA warnings, and future-dated normal requests with OCHA cluster assignments
+- **Completed dispatches:** Creates validated outgoing pickings with beneficiary counts, POD GPS coordinates, and delivery confirmation for dashboard KPIs
+- **Personnel:** Deployed staff with Sri Lankan names, random roles/organizations/clusters, and varied deployment statuses
+- **Alerts:** Creates guaranteed sample alerts (low stock, SLA breach, SLA warning) plus runs the alert engine cron jobs to generate additional alerts
+
+### Area Import
+
+Imports Sri Lanka administrative boundaries from an Excel file using the `spp.area.import` system, then assigns area types based on admin level. Links warehouses to their geographic areas and adds GPS coordinates. Optionally imports HDX polygon boundaries (GeoJSON) for choropleth maps using geometry simplification via Shapely.
+
+## Integration
+
+- **spp_drims_sl:** Uses the Sri Lanka configuration (warehouses, products, agencies, users) as the foundation for demo data generation.
+- **spp_area_hdx:** Imports HDX COD polygon boundaries for provinces and districts to enable geographic visualization.
+- **spp_gis_report:** Refreshes GIS report data after demo generation for choropleth display. Extends GIS report source models to include DRIMS requests.

--- a/docs/reference/modules/spp_encryption.md
+++ b/docs/reference/modules/spp_encryption.md
@@ -1,0 +1,73 @@
+---
+openspp:
+  doc_status: draft
+---
+
+# Encryption: Base
+
+**Module:** `spp_encryption`
+
+## Overview
+
+Implements advanced cryptographic services for OpenSPP, enabling data encryption, decryption, digital signing, and signature verification for sensitive program information. It securely manages cryptographic keys in JWK format and distributes public keys via JWKS, facilitating secure inter-system verification and data integrity.
+
+## Purpose
+
+This module is designed to:
+
+- **Encrypt and decrypt data:** Provide JWE (JSON Web Encryption) services using RSA-OAEP with A256GCM for protecting sensitive program data.
+- **Sign and verify tokens:** Create and verify JWT (JSON Web Tokens) using RS256 for secure inter-system authentication and data integrity.
+- **Distribute public keys:** Expose public keys in JWKS (JSON Web Key Set) format for external systems to verify signatures.
+- **Sign credentials with Linked Data Proofs:** Support JSON-LD credential signing with URDNA2015 normalization and multiple proof types (RSA, ECDSA, Ed25519), with a fallback for environments without remote context access.
+
+## Module Dependencies
+
+| Dependency | Purpose |
+| --- | --- |
+| `spp_security` | Central security definitions for OpenSPP modules |
+| `spp_key_management` | Centralized cryptographic key management with pluggable p... |
+
+### External Dependencies
+
+| Package | Purpose |
+| --- | --- |
+| `jwcrypto>=1.5.6` | |
+
+## Key Features
+
+### Encryption Provider
+
+The base model (`spp.encryption.provider`) defines a pluggable interface with type-dispatched methods:
+
+| Method | Description |
+| --- | --- |
+| `encrypt_data()` | Encrypt raw bytes using JWE |
+| `decrypt_data()` | Decrypt JWE-encrypted data |
+| `jwt_sign()` | Sign data and return a JWT string |
+| `jwt_verify()` | Verify a JWT signature and return validity |
+| `get_jwks()` | Get public keys in JWKS format |
+| `sign_credential_ld_proof()` | Sign a JSON-LD credential with Linked Data Proof |
+
+### JWCrypto Implementation
+
+The JWCrypto provider (`type = "jwcrypto"`) implements all operations using the `jwcrypto` Python library:
+
+- **Key storage:** Links to `spp.asymmetric.key` records from `spp_key_management` for secure encrypted key storage
+- **Key generation:** Supports RSA (2048/3072/4096-bit), EC (P-256, P-384, P-521, secp256k1), and Ed25519 key types via a UI action
+- **Encryption:** Uses JWE with RSA-OAEP algorithm and A256GCM content encryption
+- **Signing:** Uses JWT with RS256 algorithm
+
+### Linked Data Proof Signing
+
+For verifiable credential use cases, the module supports JSON-LD proof signing:
+
+- Normalizes proof and credential documents using URDNA2015 algorithm
+- Creates SHA-256 digests of normalized documents
+- Signs the combined digest using JWT
+- Includes bundled local copies of W3C security and credentials contexts to avoid network dependencies
+- Configurable fallback to deterministic JSON serialization when JSON-LD normalization fails
+
+## Integration
+
+- **spp_key_management:** Delegates all key storage and retrieval to the centralized key management module, ensuring keys are stored encrypted.
+- **spp_security:** Inherits security group definitions for access control to encryption operations.

--- a/docs/reference/modules/spp_event_data.md
+++ b/docs/reference/modules/spp_event_data.md
@@ -22,14 +22,14 @@ This module is designed to:
 
 ## Module Dependencies
 
-| Dependency          | Description                                |
-| ------------------- | ------------------------------------------ |
-| **base**            | Core Odoo framework                        |
-| **mail**            | Messaging and activity tracking            |
-| **spp_registry**    | OpenSPP registry for registrant management |
-| **spp_base_common** | Common OpenSPP utilities                   |
-| **spp_security**    | OpenSPP security framework                 |
-| **spp_approval**    | Approval workflow support                  |
+| Dependency | Purpose |
+| --- | --- |
+| `base` | Odoo core framework |
+| `mail` | Communication and activity tracking |
+| `spp_registry` | Consolidated registry management for individuals, groups,... |
+| `spp_base_common` | The OpenSPP base module that provides the main menu, gene... |
+| `spp_security` | Central security definitions for OpenSPP modules |
+| `spp_approval` | Standardized approval workflows with multi-tier sequencin... |
 
 ## Key Features
 
@@ -186,12 +186,3 @@ Use the "Create Event" wizard to record events:
 | Cron Job      | Description                                                |
 | ------------- | ---------------------------------------------------------- |
 | Expire Events | Automatically expires active events past their expiry date |
-
-## Technical Details
-
-### Hooks
-
-The module provides installation hooks:
-
-- `post_init_hook`: Runs after module installation
-- `uninstall_hook`: Cleanup when module is removed

--- a/docs/reference/modules/spp_farmer_registry.md
+++ b/docs/reference/modules/spp_farmer_registry.md
@@ -1,0 +1,126 @@
+---
+openspp:
+  doc_status: draft
+---
+
+# Farmer Registry
+
+**Module:** `spp_farmer_registry`
+
+## Overview
+
+Farmer Registry with vocabulary-based fields, CEL variables, and Logic Studio integration
+
+## Purpose
+
+This module is designed to:
+
+- **Register farms as groups:** Extend `res.partner` with farm-specific fields using `_inherits` delegation to `spp.farm.details`, so farms are first-class registrants.
+- **Classify farm details:** Record farm type, land tenure, holder type, and data source using FAO-aligned vocabulary codes instead of fixed selection fields.
+- **Track agricultural activities:** Manage crop, livestock, and aquaculture activities with cascading species selection from FAO ICC, FAO Livestock, and FAO ASFIS vocabularies.
+- **Manage farm assets and land:** Track equipment, machinery, and extension services; link to land records and irrigation modules for parcel-level management.
+- **Provide CEL variables:** Extend the CEL variable system with farm-specific aggregate targets for building eligibility rules based on farm data.
+- **Manage agricultural seasons:** Control when farm activities can be recorded with a state machine (draft, active, closed) and overlap prevention.
+
+## Module Dependencies
+
+| Dependency | Purpose |
+| --- | --- |
+| `spp_registry` | Consolidated registry management for individuals, groups,... |
+| `spp_registry_search` | Search-first registry interface for privacy protection |
+| `spp_security` | Central security definitions for OpenSPP modules |
+| `spp_area` | Establishes direct associations between OpenSPP registran... |
+| `spp_vocabulary` | OpenSPP: Vocabulary |
+| `spp_farmer_registry_vocabularies` | FAO-aligned vocabularies for farmer registry (crops, live... |
+| `spp_cel_domain` | Write simple CEL-like expressions to filter records (Open... |
+| `spp_studio` | No-code customization interface for OpenSPP |
+| `spp_land_record` | The OpenSPP Land Record module digitizes and centralizes ... |
+| `spp_irrigation` | Manages detailed irrigation assets by type, capacity, and... |
+| `spp_gis` | GIS core plus area geo fields and importer extensions (po... |
+
+### External Dependencies
+
+| Package | Purpose |
+| --- | --- |
+| `shapely` | |
+| `geojson` | |
+| `pyproj` | |
+
+## Key Features
+
+### Farm Details
+
+Farm classification fields are stored in `spp.farm.details` and accessed transparently on the partner via delegation:
+
+| Field | Vocabulary Namespace | Description |
+| --- | --- | --- |
+| Farm Type | `urn:openspp:vocab:farm-type` | Crop, livestock, aquaculture, or mixed |
+| Land Tenure | `urn:openspp:vocab:land-tenure` | Ownership or use rights classification |
+| Holder Type | `urn:openspp:vocab:holder-type` | Individual, joint, or institutional (FAO WCA 2020) |
+| Data Source | `urn:openspp:vocab:data-source` | Census, self-registration, or field visit |
+
+Acreage fields track total farm size and breakdown by use (crops, livestock, aquaculture, leased out, fallow).
+
+### Computed Farm Indicators
+
+| Field | Description |
+| --- | --- |
+| `farm_size_hectares` | Alias for total farm size used by CEL variables |
+| `is_smallholder` | True if total size is at or below configurable threshold (default 5 ha) |
+| `has_productive_land` | True if any land is under crops, livestock, or aquaculture |
+| `total_livestock_heads` | Sum of all livestock activity quantities |
+
+### Agricultural Activities
+
+Activities (`spp.farm.activity`) use cascading vocabulary selection based on activity type:
+
+| Activity Type | Species Vocabulary |
+| --- | --- |
+| Crop Cultivation | `urn:fao:icc:1.1` (FAO ICC Crop Classification) |
+| Livestock Rearing | `urn:fao:livestock:2020` (FAO Livestock Classification) |
+| Aquaculture | `urn:fao:asfis:2024` (FAO ASFIS Species List) |
+
+Activities track quantity, area planted, expected/actual yield, purpose, cultivation method, and link to agricultural seasons and land parcels.
+
+### Agricultural Seasons
+
+Seasons (`spp.farm.season`) control when activities can be recorded:
+
+- State machine: Draft, Active, Closed with manager-only transitions
+- Overlap prevention between active seasons (configurable)
+- Force close option for closing before end date
+- Prevents activity modifications in closed seasons
+
+### CEL Variable Extension
+
+Extends CEL variables with farm-specific aggregate targets for building eligibility expressions:
+
+| Target | Related Field |
+| --- | --- |
+| `farm_crop_activities` | `farm_crop_act_ids` |
+| `farm_livestock_activities` | `farm_livestock_act_ids` |
+| `farm_aquaculture_activities` | `farm_aquaculture_act_ids` |
+| `land_parcels` | `farm_land_rec_ids` |
+
+### GIS Support
+
+Farms can have GPS coordinates stored as GeoJSON points. The `get_geojson()` method generates GeoJSON FeatureCollections with coordinate transformation from EPSG:3857 to WGS84.
+
+## Integration
+
+- **spp_registry:** Farms are `res.partner` records (groups) with `_inherits` delegation to `spp.farm.details`.
+- **spp_vocabulary / spp_farmer_registry_vocabularies:** All classification fields use vocabulary codes with FAO-aligned namespace URIs.
+- **spp_cel_domain / spp_studio:** CEL variables with farm-specific aggregate targets enable no-code eligibility rule building.
+- **spp_land_record:** Land parcels are linked to farms and activities for parcel-level tracking.
+- **spp_irrigation:** Irrigation assets are associated with farm land parcels.
+- **spp_gis:** Farm GPS coordinates enable geographic visualization.
+
+```{toctree}
+:maxdepth: 1
+:hidden:
+
+spp_farmer_registry_cr
+spp_farmer_registry_dashboard
+spp_farmer_registry_demo
+spp_farmer_registry_vocabularies
+```

--- a/docs/reference/modules/spp_farmer_registry_cr.md
+++ b/docs/reference/modules/spp_farmer_registry_cr.md
@@ -1,0 +1,67 @@
+---
+openspp:
+  doc_status: draft
+---
+
+# Change Request Types
+
+**Module:** `spp_farmer_registry_cr`
+
+## Overview
+
+Farmer-specific change request types for farm details and activities
+
+## Purpose
+
+This module is designed to:
+
+- **Update farm details via change requests:** Enable field officers to propose changes to farm classification (type, tenure, size) through an approval workflow before modifying the registry.
+- **Manage farm activities via change requests:** Support adding, editing, and removing crop, livestock, and aquaculture activities through controlled change requests.
+- **Manage land parcels via change requests:** Handle land parcel additions, updates, and removals with approval before applying to the farm record.
+- **Manage farm assets via change requests:** Control asset and machinery changes through the change request workflow.
+
+## Module Dependencies
+
+| Dependency | Purpose |
+| --- | --- |
+| `spp_change_request_v2` | Configuration-driven change request system with UX improv... |
+| `spp_farmer_registry` | Farmer Registry with vocabulary-based fields, CEL variabl... |
+| `spp_land_record` | The OpenSPP Land Record module digitizes and centralizes ... |
+
+## Key Features
+
+### Change Request Types
+
+The module registers four farmer-specific change request types via XML data:
+
+| CR Type | Description |
+| --- | --- |
+| Update Farm Details | Modify farm type, holder type, land tenure, acreage, and other classification fields |
+| Manage Farm Activity | Add, edit, or remove crop/livestock/aquaculture activities |
+| Manage Land Parcel | Add, edit, or remove land parcel records |
+| Manage Farm Asset | Add, edit, or remove farm assets and machinery |
+
+### Operation Controls
+
+Each change request type has configurable operation toggles:
+
+| Toggle | Controls |
+| --- | --- |
+| `allow_activity_add/update/remove` | Whether activities can be added, edited, or removed |
+| `allow_parcel_add/update/remove` | Whether land parcels can be added, edited, or removed |
+| `allow_asset_add/update/remove` | Whether assets can be added, edited, or removed |
+
+### Apply Strategies
+
+Each CR type has a corresponding apply strategy that validates and applies changes to the farm registrant:
+
+- **Update Farm Details:** Copies vocabulary-based fields and acreage values from the CR detail to the farm
+- **Manage Farm Activity:** Creates, updates, or deletes activity records based on the operation type
+- **Manage Land Parcel:** Creates, updates, or deletes land record entries
+- **Manage Farm Asset:** Creates, updates, or deletes asset/machinery entries
+
+## Integration
+
+- **spp_change_request_v2:** Uses the V2 change request framework with detail models, apply strategies, and approval definitions.
+- **spp_farmer_registry:** Targets farm registrants (groups with farm details) and applies changes to farm-specific fields and related records.
+- **spp_land_record:** Land parcel change requests create or modify `spp.land.record` entries linked to farms.

--- a/docs/reference/modules/spp_farmer_registry_dashboard.md
+++ b/docs/reference/modules/spp_farmer_registry_dashboard.md
@@ -1,0 +1,47 @@
+---
+openspp:
+  doc_status: draft
+---
+
+# Dashboard
+
+**Module:** `spp_farmer_registry_dashboard`
+
+## Overview
+
+Farmer registry dashboard with CEL-based metrics and trends
+
+## Purpose
+
+This module is designed to:
+
+- **Display farmer registry metrics:** Provide pre-configured dashboard metrics for monitoring farmer registrations, farm types, land usage, and activity trends.
+- **Leverage CEL-based computation:** Use CEL variables and the dashboard base framework to compute and display farmer-specific KPIs.
+
+## Module Dependencies
+
+| Dependency | Purpose |
+| --- | --- |
+| `spp_farmer_registry` | Farmer Registry with vocabulary-based fields, CEL variabl... |
+| `spp_dashboard_base` |  |
+| `spp_studio` | No-code customization interface for OpenSPP |
+| `spreadsheet_dashboard` | Spreadsheet-based dashboards |
+| `spp_security` | Central security definitions for OpenSPP modules |
+
+## Key Features
+
+### Dashboard Configuration
+
+The module installs via XML data files:
+
+- **Dashboard metrics:** Pre-defined metric definitions for farmer registry KPIs
+- **Dashboards:** Spreadsheet-based dashboard layouts configured for the farmer registry context
+
+This is a data-only module with no Python models of its own. All dashboard rendering and metric computation is handled by the `spp_dashboard_base` and `spreadsheet_dashboard` dependencies.
+
+## Integration
+
+- **spp_farmer_registry:** Reads farm data (registrants, activities, land records) to compute dashboard metrics.
+- **spp_dashboard_base:** Provides the dashboard metric computation framework.
+- **spp_studio:** Enables no-code configuration of additional dashboard metrics.
+- **spreadsheet_dashboard:** Renders the dashboard using Odoo's spreadsheet dashboard framework.

--- a/docs/reference/modules/spp_farmer_registry_demo.md
+++ b/docs/reference/modules/spp_farmer_registry_demo.md
@@ -1,0 +1,77 @@
+---
+openspp:
+  doc_status: draft
+---
+
+# Demo
+
+**Module:** `spp_farmer_registry_demo`
+
+## Overview
+
+Demo generator for Farmer Registry with fixed stories and volume generation
+
+## Purpose
+
+This module is designed to:
+
+- **Generate fixed story farms:** Create eight detailed farmer personas with complete farm data (activities, land parcels, assets) for demonstration and testing.
+- **Generate volume data:** Create additional randomized farms using a seeded generator for realistic dashboard populations.
+- **Create demo programs:** Set up sample programs with cycles, enrollments, entitlements, and payments using proper Odoo workflow methods.
+- **Demonstrate change requests:** Generate sample change requests for farm detail updates to showcase the approval workflow.
+
+## Module Dependencies
+
+| Dependency | Purpose |
+| --- | --- |
+| `spp_starter_farmer_registry` | Complete Farmer Registry bundle with API, DCI, and Progra... |
+| `spp_demo` | Core demo module with data generator and sample data for ... |
+| `spp_farmer_registry_cr` | Farmer-specific change request types for farm details and... |
+| `spp_studio` | No-code customization interface for OpenSPP |
+| `spp_registry_group_hierarchy` | The module introduces hierarchical relationships among Op... |
+| `spp_area` | Establishes direct associations between OpenSPP registran... |
+| `spp_programs` | Manage cash and in-kind entitlements, integrate with inve... |
+
+## Key Features
+
+### Demo Generator Wizard
+
+A wizard-based generator creates demo data in a controlled sequence:
+
+1. **Areas:** Creates Philippine administrative areas (provinces) with GPS coordinates
+2. **Story farms:** Eight fixed farmer personas from blueprints with complete data
+3. **Volume farms:** Additional randomized farms using `SeededFarmGenerator` for reproducible output
+4. **Programs:** Demo programs created via `demo_programs` module with proper Odoo flows
+5. **Enrollments and payments:** Full program lifecycle via state machine transitions
+
+### Farmer Blueprints
+
+Fixed story farms provide realistic, complete test data covering various scenarios:
+
+- Different farm types (crop, livestock, mixed)
+- Various land tenure situations
+- Multiple activity types with species from FAO vocabularies
+- Land parcels with GIS coordinates
+- Farm assets and machinery
+
+### Seeded Farm Generator
+
+The `SeededFarmGenerator` class uses deterministic random generation (seeded) to produce reproducible farm data. This ensures consistent demo environments across installations while providing realistic variation in farm sizes, activity types, and geographic distribution.
+
+### Demo Programs
+
+Creates sample social protection programs with:
+
+- Program configuration via XML data
+- Cycle creation and enrollment
+- Entitlement generation and payment processing
+- Logic pack integration for eligibility rules
+
+## Integration
+
+- **spp_starter_farmer_registry:** Uses the complete farmer registry bundle as the foundation.
+- **spp_demo:** Extends the core demo infrastructure for data generation.
+- **spp_farmer_registry_cr:** Creates sample change requests to demonstrate the approval workflow.
+- **spp_programs:** Creates demo programs with full lifecycle (cycles, entitlements, payments).
+- **spp_area:** Creates geographic areas for farm location assignment.
+- **spp_registry_group_hierarchy:** Supports hierarchical group relationships in demo data.

--- a/docs/reference/modules/spp_farmer_registry_vocabularies.md
+++ b/docs/reference/modules/spp_farmer_registry_vocabularies.md
@@ -1,0 +1,71 @@
+---
+openspp:
+  doc_status: draft
+---
+
+# Vocabularies
+
+**Module:** `spp_farmer_registry_vocabularies`
+
+## Overview
+
+FAO-aligned vocabularies for farmer registry (crops, livestock, aquaculture)
+
+## Purpose
+
+This module is designed to:
+
+- **Provide FAO-aligned vocabularies:** Install pre-configured vocabulary codes for farm type, land tenure, land use, cultivation method, activity purpose, holder type, data source, and irrigation asset types.
+- **Supply species vocabularies:** Provide default crop, livestock, and aquaculture species codes aligned with FAO classification systems (ICC, FAO Livestock, ASFIS).
+- **Import AGROVOC data:** Enable bulk import of AGROVOC RDF vocabulary data with filtering, hierarchy preservation, and multilingual label extraction.
+
+## Module Dependencies
+
+| Dependency | Purpose |
+| --- | --- |
+| `spp_vocabulary` | OpenSPP: Vocabulary |
+| `job_worker` | Background job worker |
+
+## Key Features
+
+### Pre-installed Vocabularies
+
+The module installs vocabulary codes via XML data files:
+
+| Vocabulary | Namespace URI | Description |
+| --- | --- | --- |
+| Farm Type | `urn:openspp:vocab:farm-type` | Crop, livestock, aquaculture, mixed |
+| Land Tenure | `urn:openspp:vocab:land-tenure` | Ownership and use rights |
+| Land Use | `urn:openspp:vocab:land-use` | Land use classification |
+| Cultivation Method | `urn:openspp:vocab:cultivation-method` | Irrigated, rainfed |
+| Activity Purpose | `urn:openspp:vocab:activity-purpose` | Subsistence, commercial, both |
+| Holder Type | `urn:openspp:vocab:holder-type` | Individual, joint, institutional (FAO WCA 2020) |
+| Data Source | `urn:openspp:vocab:data-source` | Census, self-registration, field visit |
+| Irrigation Asset Type | `urn:openspp:vocab:irrigation-asset-type` | Types of irrigation infrastructure |
+
+### Species Vocabularies
+
+Default species codes for the three activity types:
+
+| Vocabulary | Namespace URI | Source Standard |
+| --- | --- | --- |
+| Crops | `urn:fao:icc:1.1` | FAO Indicative Crop Classification |
+| Livestock | `urn:fao:livestock:2020` | FAO Livestock Classification |
+| Aquaculture | `urn:fao:asfis:2024` | FAO ASFIS Species List |
+
+### AGROVOC Import
+
+The AGROVOC import system (`spp.agrovoc.import`) supports batch import from RDF N-Triples files:
+
+- **Filtering modes:** Import all concepts, filter by root concept hierarchy (e.g., only cereals), or import a specific list of concept codes
+- **Hierarchy support:** Extracts parent-child relationships from SKOS broader/narrower relations with configurable maximum depth
+- **Multilingual labels:** Extracts labels in a primary language plus configurable additional languages
+- **Background processing:** Uses `job_worker` for scalable processing of large datasets
+- **Preview mode:** Preview what would be imported before executing
+
+A wizard (`spp.agrovoc.import.wizard`) provides a user-friendly interface for uploading files, selecting the target vocabulary type, and previewing results before import.
+
+## Integration
+
+- **spp_vocabulary:** All vocabulary codes are stored in `spp.vocabulary.code` records and referenced by `spp_farmer_registry` for farm classification and species selection.
+- **job_worker:** AGROVOC import processing runs as background jobs for handling large RDF datasets without blocking the UI.

--- a/docs/reference/modules/spp_gis.md
+++ b/docs/reference/modules/spp_gis.md
@@ -22,25 +22,23 @@ This module is designed to:
 
 ## Module Dependencies
 
-| Dependency     | Description                                |
-| -------------- | ------------------------------------------ |
-| `base`         | Odoo core framework                        |
-| `web`          | Odoo web framework for map views           |
-| `contacts`     | Contact/partner management                 |
-| `spp_security` | OpenSPP security groups and access control |
-| `spp_area`     | Administrative area hierarchy              |
+| Dependency | Purpose |
+| --- | --- |
+| `base` | Odoo core framework |
+| `web` | Web interface components |
+| `contacts` | Base contact model extension |
+| `spp_security` | Central security definitions for OpenSPP modules |
+| `spp_area` | Establishes direct associations between OpenSPP registran... |
+| `spp_vocabulary` | OpenSPP: Vocabulary |
+| `spp_registry` | Consolidated registry management for individuals, groups,... |
 
-### External Python Dependencies
+### External Dependencies
 
-| Package   | Description                               |
-| --------- | ----------------------------------------- |
-| `shapely` | Geometric operations and spatial analysis |
-| `pyproj`  | Coordinate system transformations         |
-| `geojson` | GeoJSON format handling                   |
-
-### Database Requirements
-
-This module requires PostGIS extension for PostgreSQL. The `pre_init_hook` automatically initializes PostGIS when the module is installed.
+| Package | Purpose |
+| --- | --- |
+| `shapely` | |
+| `pyproj` | |
+| `geojson` | |
 
 ## Key Features
 
@@ -131,3 +129,13 @@ Visualize program coverage geographically:
 - Map beneficiary locations by program
 - Show coverage gaps by area
 - Analyze geographic distribution of entitlements
+
+```{toctree}
+:maxdepth: 1
+:hidden:
+
+spp_gis_indicators
+spp_gis_report
+spp_gis_report_programs
+spp_registrant_gis
+```

--- a/docs/reference/modules/spp_gis_indicators.md
+++ b/docs/reference/modules/spp_gis_indicators.md
@@ -1,0 +1,69 @@
+---
+openspp:
+  doc_status: draft
+---
+
+# Indicators
+
+**Module:** `spp_gis_indicators`
+
+## Overview
+
+Choropleth visualization for area-level indicators
+
+## Purpose
+
+This module is designed to:
+
+- **Visualize area-level indicators as choropleth maps:** Map CEL variable values to color-coded geographic areas for spatial analysis of social protection metrics.
+- **Define color scales:** Create and manage reusable color schemes (sequential, diverging, categorical) based on ColorBrewer palettes for data visualization.
+- **Configure indicator layers:** Link CEL variables to color scales with classification methods to control how data values are mapped to colors on the map.
+
+## Module Dependencies
+
+| Dependency | Purpose |
+| --- | --- |
+| `spp_gis` | GIS core plus area geo fields and importer extensions (po... |
+| `spp_hxl_area` | HXL import with area-level aggregation for humanitarian i... |
+| `spp_registry` | Consolidated registry management for individuals, groups,... |
+| `spp_security` | Central security definitions for OpenSPP modules |
+
+## Key Features
+
+### Color Scales
+
+Color scales define the color palettes used for choropleth visualization.
+
+| Field | Description |
+| --- | --- |
+| Scale Name | Name of the color scheme (e.g., "Blues", "RdYlGn") |
+| Scale Type | Sequential (low to high), Diverging (negative to positive), or Categorical (distinct values) |
+| Colors (JSON) | JSON array of hex color codes (minimum 2 colors required) |
+
+The module validates hex color format (#RGB or #RRGGBB) and provides a `get_color_for_value` method that maps data values to colors based on the scale type. Sequential scales use linear mapping, while diverging scales map relative to a center point.
+
+### Indicator Layer Configuration
+
+Indicator layers configure how area-level indicators appear as choropleth maps.
+
+| Field | Description |
+| --- | --- |
+| Indicator Variable | CEL variable containing area-level indicator values |
+| Period Key | Period identifier for filtering (e.g., "2024-12", "current") |
+| Incident/Disaster | Optional filter by specific hazard incident |
+| Color Scale | Color scheme to use |
+| Classification Method | Quantile (equal count per class), Equal Interval (equal range per class), or Manual Breaks |
+| Number of Classes | Number of color classes (2-10) |
+| Manual Break Points | Comma-separated break values for manual classification |
+
+The module computes break values from actual indicator data and generates an HTML legend showing the color-to-value mapping for display on the map.
+
+### Data Layer Extension
+
+The module extends `spp.gis.data.layer` to support indicator-based choropleth visualization. Choropleth layers can be configured with either a direct value field or an indicator layer configuration, and the `get_feature_colors` method returns a mapping of area IDs to hex colors for rendering.
+
+## Integration
+
+- **spp_gis:** Extends the GIS data layer model to add indicator-based choropleth configuration alongside the base field-based approach.
+- **spp_hxl_area:** Reads indicator values from `spp.hxl.area.indicator` records to compute classification breaks and assign colors per area.
+- **spp_hazard:** Optionally filters indicators by hazard incident via the `incident_id` field on indicator layer configuration.

--- a/docs/reference/modules/spp_gis_report.md
+++ b/docs/reference/modules/spp_gis_report.md
@@ -3,7 +3,7 @@ openspp:
   doc_status: draft
 ---
 
-# GIS Reports
+# Reports
 
 **Module:** `spp_gis_report`
 
@@ -22,21 +22,21 @@ This module is designed to:
 
 ## Module Dependencies
 
-| Dependency       | Description                                  |
-| ---------------- | -------------------------------------------- |
-| `spp_area`       | Administrative area hierarchy                |
-| `spp_gis`        | Core GIS functionality and geometry fields   |
-| `spp_registry`   | Registry data for aggregation                |
-| `spp_vocabulary` | Vocabulary terms for categorization          |
-| `spp_cel_domain` | CEL expressions for data filtering           |
-| `queue_job`      | Background job processing for large datasets |
+| Dependency | Purpose |
+| --- | --- |
+| `spp_area` | Establishes direct associations between OpenSPP registran... |
+| `spp_gis` | GIS core plus area geo fields and importer extensions (po... |
+| `spp_registry` | Consolidated registry management for individuals, groups,... |
+| `spp_vocabulary` | OpenSPP: Vocabulary |
+| `spp_cel_domain` | Write simple CEL-like expressions to filter records (Open... |
+| `job_worker` | Background job worker |
 
-### External Python Dependencies
+### External Dependencies
 
-| Package   | Description                           |
-| --------- | ------------------------------------- |
-| `numpy`   | Numerical computations for statistics |
-| `shapely` | Geometric operations                  |
+| Package | Purpose |
+| --- | --- |
+| `numpy>=1.22.2` | |
+| `shapely` | |
 
 ## Key Features
 

--- a/docs/reference/modules/spp_gis_report_programs.md
+++ b/docs/reference/modules/spp_gis_report_programs.md
@@ -1,0 +1,46 @@
+---
+openspp:
+  doc_status: draft
+---
+
+# Reports - Programs
+
+**Module:** `spp_gis_report_programs`
+
+## Overview
+
+Add program context filtering to GIS reports
+
+## Purpose
+
+This module is designed to:
+
+- **Filter GIS reports by program:** Add program context to GIS reports so that geographic visualizations can be scoped to registrants enrolled in a specific program.
+- **Extend the report wizard:** Allow users to select a program when generating a GIS report, enforcing program selection when a template requires it.
+
+## Module Dependencies
+
+| Dependency | Purpose |
+| --- | --- |
+| `spp_gis_report` | Geographic visualization and reporting for social protect... |
+| `spp_programs` | Manage cash and in-kind entitlements, integrate with inve... |
+
+## Key Features
+
+### Program Context Filter on GIS Reports
+
+The module adds a `Program Context` field to the GIS report model. When a program is selected and the report's source model is `res.partner`, the report domain is extended to include only registrants enrolled in that program (via `program_membership_ids.program_id`).
+
+### Report Wizard Extension
+
+The GIS report wizard gains a `Program` field. When generating a report:
+
+- The selected program is validated if the template requires it.
+- The program ID is included in the report creation values.
+- The program ID is appended to the report code suffix to ensure unique report codes per program.
+
+## Integration
+
+- **spp_gis_report:** Extends the report model (`spp.gis.report`) and wizard (`spp.gis.report.wizard`) with program context filtering.
+- **spp_programs:** Uses the `spp.program` model and filters registrants by their `program_membership_ids` relationship.
+- **Auto-install:** This module auto-installs when both `spp_gis_report` and `spp_programs` are present.

--- a/docs/reference/modules/spp_graduation.md
+++ b/docs/reference/modules/spp_graduation.md
@@ -1,0 +1,81 @@
+---
+openspp:
+  doc_status: draft
+---
+
+# Graduation Management
+
+**Module:** `spp_graduation`
+
+## Overview
+
+Manage graduation and exit from time-bound social protection programs
+
+## Purpose
+
+This module is designed to:
+
+- **Define graduation pathways:** Configure structured exit paths from social protection programs, distinguishing between positive exits (graduation) and negative exits (removal).
+- **Assess beneficiary readiness:** Record and score criteria-based assessments to determine whether a beneficiary is ready to graduate from a program.
+- **Manage approval workflows:** Route graduation assessments through draft, submitted, approved, and rejected states with full audit tracking.
+
+## Module Dependencies
+
+| Dependency | Purpose |
+| --- | --- |
+| `base` | Odoo core framework |
+| `spp_registry` | Consolidated registry management for individuals, groups,... |
+| `spp_security` | Central security definitions for OpenSPP modules |
+| `mail` | Communication and activity tracking |
+
+### External Dependencies
+
+| Package | Purpose |
+| --- | --- |
+| `python-dateutil` | Date arithmetic for computing post-graduation monitoring end dates |
+
+## Key Features
+
+### Graduation Pathways
+
+Pathways define how beneficiaries exit a program. Each pathway specifies whether the exit is positive (graduation) or negative (removal), and whether an assessment and approval are required.
+
+| Field | Description |
+| --- | --- |
+| Name / Code | Identifier for the pathway |
+| Is Positive Exit | Distinguishes graduation from removal |
+| Is Assessment Required | Whether a formal assessment must be completed |
+| Is Approval Required | Whether a supervisor must approve the exit |
+| Post Graduation Monitoring Months | Duration of monitoring after graduation (default: 12 months) |
+
+### Graduation Criteria
+
+Each pathway has one or more criteria that define what readiness means. Criteria are weighted and can be marked as required (must be met regardless of overall score).
+
+| Field | Description |
+| --- | --- |
+| Name / Code | Identifier for the criterion |
+| Weight | Relative importance in the overall score calculation (must be > 0) |
+| Assessment Method | Self Report, Verification Required, Computed from Data, or Field Observation |
+| Is Required | If true, must be individually met regardless of overall score |
+
+### Graduation Assessments
+
+Assessments evaluate a beneficiary against a pathway's criteria. Each assessment includes criteria responses with scores (0-1), evidence attachments, and an overall recommendation.
+
+| Field | Description |
+| --- | --- |
+| Beneficiary | The registrant being assessed |
+| Pathway | The graduation pathway used for evaluation |
+| Assessor | User conducting the assessment |
+| Readiness Score | Computed weighted average of criteria response scores (0-1) |
+| Is Required Criteria Met | Whether all required criteria have been individually met |
+| Recommendation | Graduate, Extend Participation, Exit (Non-graduation), or Defer Assessment |
+| State | Draft, Submitted, Approved, or Rejected |
+
+When an assessment is approved with a "Graduate" recommendation, the graduation date is automatically set. The monitoring end date is computed based on the pathway's post-graduation monitoring period.
+
+## Integration
+
+- **spp_registry:** Links assessments to registrants via `partner_id` with domain filtering for `is_registrant = True`.
+- **mail:** Uses `mail.thread` and `mail.activity.mixin` on assessments for chatter-based audit trails and state change tracking.

--- a/docs/reference/modules/spp_grm.md
+++ b/docs/reference/modules/spp_grm.md
@@ -23,15 +23,15 @@ This module is designed to:
 
 ## Module Dependencies
 
-| Dependency       | Description                             |
-| ---------------- | --------------------------------------- |
-| `base`           | Odoo core framework                     |
-| `mail`           | Email integration and chatter           |
-| `portal`         | Beneficiary self-service portal         |
-| `spp_registry`   | Registrant records for linking          |
-| `spp_area`       | Administrative areas for ticket routing |
-| `spp_user_roles` | Role-based access for GRM teams         |
-| `spp_security`   | Security groups and access control      |
+| Dependency | Purpose |
+| --- | --- |
+| `base` | Odoo core framework |
+| `mail` | Communication and activity tracking |
+| `portal` | Portal access capabilities |
+| `spp_registry` | Consolidated registry management for individuals, groups,... |
+| `spp_area` | Establishes direct associations between OpenSPP registran... |
+| `spp_user_roles` | The OpenSPP User Roles module defines and manages distinc... |
+| `spp_security` | Central security definitions for OpenSPP modules |
 
 ## Key Features
 
@@ -182,3 +182,14 @@ When `spp_grm_cel` module is installed:
 - Define escalation rules with CEL expressions
 - Automatic routing based on ticket attributes
 - Complex escalation workflows
+
+```{toctree}
+:maxdepth: 1
+:hidden:
+
+spp_grm_case_link
+spp_grm_cel
+spp_grm_demo
+spp_grm_programs
+spp_grm_registry
+```

--- a/docs/reference/modules/spp_grm_case_link.md
+++ b/docs/reference/modules/spp_grm_case_link.md
@@ -1,0 +1,68 @@
+---
+openspp:
+  doc_status: draft
+---
+
+# Case Link
+
+**Module:** `spp_grm_case_link`
+
+## Overview
+
+Links GRM tickets with Case Management cases for escalation
+
+## Purpose
+
+This module is designed to:
+
+- **Escalate GRM tickets to cases:** Provide a wizard-driven workflow for converting grievance tickets into formal case management records.
+- **Link tickets and cases bidirectionally:** Track which GRM ticket originated a case and which cases have related tickets.
+- **Create follow-up tickets from cases:** Allow case workers to create new GRM tickets linked to an existing case.
+
+## Module Dependencies
+
+| Dependency | Purpose |
+| --- | --- |
+| `spp_security` | Central security definitions for OpenSPP modules |
+| `spp_grm` | Provides a centralized Grievance Redress Mechanism for re... |
+| `spp_case_base` | Core case management functionality for OpenSPP |
+
+## Key Features
+
+### Ticket-to-Case Escalation Wizard
+
+The escalation wizard (`spp.grm.escalate.wizard`) guides users through creating a case from a GRM ticket. The wizard presents the ticket details and allows configuration of the new case.
+
+| Field | Description |
+| --- | --- |
+| Case Type | Type of case to create |
+| Intensity Level | Level 1 (Low), Level 2 (Medium), or Level 3 (High) |
+| Case Worker | Defaults to the ticket assignee |
+| Supervisor | Optionally set from the selected team |
+| Team | Team responsible for the case |
+| Copy Description | Copy the ticket description as the case's presenting issue |
+| Close Ticket | Optionally close the ticket after escalation with a decision code |
+
+The wizard validates that the ticket is not already linked to a case, creates the case record, posts cross-reference messages on both the ticket and the case chatter, and optionally closes the ticket with a "Referred to Case" decision.
+
+### Case Extensions
+
+Cases gain the following fields from this module:
+
+| Field | Description |
+| --- | --- |
+| Source GRM Ticket | The ticket that initiated this case |
+| Related Tickets | All GRM tickets linked to this case |
+| GRM Ticket Count | Computed count of related tickets |
+
+Cases also gain an action to create follow-up GRM tickets pre-populated with the case's partner and context.
+
+### Ticket Extensions
+
+Tickets gain a `Related Case` field and a smart button to view the linked case or open the escalation wizard.
+
+## Integration
+
+- **spp_grm:** Extends `spp.grm.ticket` with a `case_id` field and escalation actions.
+- **spp_case_base:** Extends `spp.case` with source ticket tracking and follow-up ticket creation.
+- **Auto-install:** This module auto-installs when both `spp_grm` and `spp_case_base` are present.

--- a/docs/reference/modules/spp_grm_cel.md
+++ b/docs/reference/modules/spp_grm_cel.md
@@ -1,0 +1,81 @@
+---
+openspp:
+  doc_status: draft
+---
+
+# CEL Rules
+
+**Module:** `spp_grm_cel`
+
+## Overview
+
+CEL-based routing and escalation rules for GRM tickets
+
+## Purpose
+
+This module is designed to:
+
+- **Route tickets automatically:** Evaluate CEL expressions against incoming tickets and assign them to the appropriate team, user, severity, and priority.
+- **Escalate tickets by rule:** Automatically escalate tickets based on CEL conditions and time-based triggers, updating severity, priority, and assignees.
+- **Schedule periodic escalation checks:** Run a cron job to evaluate escalation rules against all open tickets on a recurring basis.
+
+## Module Dependencies
+
+| Dependency | Purpose |
+| --- | --- |
+| `spp_security` | Central security definitions for OpenSPP modules |
+| `spp_grm` | Provides a centralized Grievance Redress Mechanism for re... |
+| `spp_cel_domain` | Write simple CEL-like expressions to filter records (Open... |
+| `spp_case_base` | Core case management functionality for OpenSPP |
+
+## Key Features
+
+### Routing Rules
+
+Routing rules (`spp.grm.routing.rule`) automatically assign newly created tickets based on CEL conditions. Rules are evaluated in sequence order, and the first matching rule is applied.
+
+| Field | Description |
+| --- | --- |
+| Condition (CEL) | CEL expression evaluated against ticket properties |
+| Assign to Team | Team to assign the ticket to |
+| Assign to User | User to assign the ticket to |
+| Set Severity | Override ticket severity (low, medium, high, critical) |
+| Set Priority | Override ticket priority |
+| Match Count | Statistics counter for how many tickets matched this rule |
+
+CEL expressions have access to context variables including `ticket`, `category`, `channel`, `stage`, `severity`, `priority`, `partner`, `team`, `user`, and helper functions like `days_since()`, `hours_since()`, and `is_business_day()`.
+
+### Escalation Rules
+
+Escalation rules (`spp.grm.escalation.rule`) automatically escalate tickets when conditions are met. Unlike routing rules, multiple escalation rules can apply to the same ticket.
+
+| Field | Description |
+| --- | --- |
+| Condition (CEL) | CEL expression evaluated against ticket properties |
+| Trigger After Hours | Time-based trigger (escalate if ticket is open longer than N hours) |
+| Escalate to User | User to escalate to |
+| Escalate to Team | Team to escalate to |
+| Escalate Severity/Priority | Increase severity or priority to a specified level |
+| Send Notification | Send email using a configured mail template |
+| Create Case | Automatically create a case management record |
+| Case Type | Type of case to create when escalating |
+
+### Ticket Extension
+
+The module extends `spp.grm.ticket` to:
+
+- Apply routing rules automatically on ticket creation.
+- Check escalation rules when the ticket stage changes.
+- Track which routing rule and escalation rules were applied to each ticket.
+- Provide a manual "Escalate" action for on-demand escalation rule evaluation.
+
+### Scheduled Escalation Check
+
+A cron job (`check_escalations`) periodically searches all open tickets and evaluates active escalation rules against them. This enables time-based escalation scenarios (e.g., escalate if no response within 48 hours).
+
+## Integration
+
+- **spp_cel_domain:** Uses the CEL parser to validate and evaluate rule conditions against ticket context.
+- **spp_grm:** Extends `spp.grm.ticket` with automatic routing on create and escalation on stage change.
+- **spp_case_base:** Optionally creates `spp.case` records as part of escalation actions.
+- **Auto-install:** This module auto-installs when both `spp_grm` and `spp_cel_domain` are present.

--- a/docs/reference/modules/spp_grm_demo.md
+++ b/docs/reference/modules/spp_grm_demo.md
@@ -1,0 +1,72 @@
+---
+openspp:
+  doc_status: draft
+---
+
+# Demo Data
+
+**Module:** `spp_grm_demo`
+
+## Overview
+
+Demo data generator for Grievance Redress Mechanism
+
+## Purpose
+
+This module is designed to:
+
+- **Generate realistic GRM demo tickets:** Create story-driven and volume-based grievance tickets linked to demo registrants and programs for testing and demonstration.
+- **Simulate ticket workflows:** Progress generated tickets through resolution steps, escalation, and closure with backdated timestamps for realistic timelines.
+- **Provide a configuration wizard:** Allow users to control the number, distribution, and characteristics of generated tickets through a form-based wizard.
+
+## Module Dependencies
+
+| Dependency | Purpose |
+| --- | --- |
+| `spp_demo` | Core demo module with data generator and sample data for ... |
+| `spp_grm` | Provides a centralized Grievance Redress Mechanism for re... |
+| `spp_grm_registry` | Link GRM tickets to OpenSPP registry (registrants) |
+| `spp_grm_programs` | Link GRM tickets to OpenSPP programs, entitlements, and p... |
+| `spp_security` | Central security definitions for OpenSPP modules |
+
+### External Dependencies
+
+| Package | Purpose |
+| --- | --- |
+| `faker` | Generate realistic fake data (names, dates, descriptions) for demo tickets |
+
+## Key Features
+
+### Story-Based Tickets
+
+The module includes predefined story tickets tied to demo personas (Juan Dela Cruz, Fatima Al-Rahman, Ibrahim Hassan, Ahmed Said, David Martinez, Maria Santos, Rosa Garcia, Carlos Morales). Each story includes realistic ticket titles, descriptions, categories, resolution notes, and decisions that align with cross-module demo scenarios.
+
+### Volume Ticket Generation
+
+The wizard generates configurable batches of tickets using scenario-based templates with weighted selection. Scenarios cover common complaint types (information requests, payment issues, registration updates).
+
+| Field | Description |
+| --- | --- |
+| Number of Tickets | How many volume tickets to generate (1-10,000) |
+| Days Back | Time range for backdating ticket creation |
+| Resolved % | Percentage of tickets that should be closed with a resolution |
+| Escalated % | Percentage of open tickets that should be marked as escalated |
+| Severity Distribution | Realistic distribution: 35% low, 45% medium, 15% high, 5% critical |
+| Link to Programs | Attach tickets to random programs |
+| Link to Beneficiaries | Attach tickets to random registrants |
+| Assign Teams | Assign tickets to GRM teams |
+
+### Repeat Ticket Detection
+
+The generator builds a repeat pool (10% of beneficiaries) that receives multiple tickets (30% bias), enabling testing of the repeat ticket detection feature in `spp_grm_registry`.
+
+### Demo Data
+
+The module installs predefined ticket categories (General, Payment, Eligibility, Service, Registration) and demo GRM users via XML data files.
+
+## Integration
+
+- **spp_demo:** Uses the scenario loader from `spp_demo` for ticket scenario templates.
+- **spp_grm_registry:** Sets `registrant_id`, `household_id`, and `area_id` on generated tickets when registry integration is installed.
+- **spp_grm_programs:** Links generated tickets to programs when program integration is installed.
+- **spp_grm:** Creates tickets, progresses them through stages, and applies decisions using the core GRM models.

--- a/docs/reference/modules/spp_grm_programs.md
+++ b/docs/reference/modules/spp_grm_programs.md
@@ -1,0 +1,65 @@
+---
+openspp:
+  doc_status: draft
+---
+
+# Programs Integration
+
+**Module:** `spp_grm_programs`
+
+## Overview
+
+Link GRM tickets to OpenSPP programs, entitlements, and payments
+
+## Purpose
+
+This module is designed to:
+
+- **Link GRM tickets to programs:** Associate grievance tickets with specific programs, program memberships, cycles, entitlements, and payments.
+- **Display program context on tickets:** Show enrollment status, entitlement amounts, and payment amounts directly on the ticket form.
+- **Auto-fill related fields:** Cascade field values when a program, membership, cycle, entitlement, or payment is selected on a ticket.
+
+## Module Dependencies
+
+| Dependency | Purpose |
+| --- | --- |
+| `spp_security` | Central security definitions for OpenSPP modules |
+| `spp_grm` | Provides a centralized Grievance Redress Mechanism for re... |
+| `spp_programs` | Manage cash and in-kind entitlements, integrate with inve... |
+
+## Key Features
+
+### Program-Related Fields on Tickets
+
+The module adds the following fields to `spp.grm.ticket`:
+
+| Field | Description |
+| --- | --- |
+| Related Program | The program related to the complaint |
+| Program Membership | Specific enrollment related to the complaint |
+| Program Cycle | Specific cycle related to the complaint |
+| Related Entitlement | Specific entitlement being disputed |
+| Related Payment | Specific payment being disputed |
+| Enrollment Status | Computed from the linked program membership state |
+| Entitlement Amount | Computed from the linked entitlement record |
+| Payment Amount | Computed from the linked payment record |
+
+### Cascading Field Auto-Fill
+
+When a user selects a value in one of the program-related fields, downstream fields are automatically populated:
+
+- Selecting a **registrant and program** auto-fills the program membership.
+- Selecting a **program membership** auto-fills the program and registrant.
+- Selecting a **cycle** auto-fills the program and clears entitlement/payment.
+- Selecting an **entitlement** auto-fills the cycle, program, and registrant.
+- Selecting a **payment** auto-fills the entitlement, cycle, and registrant.
+
+### Navigation Actions
+
+Smart buttons allow navigating directly from a ticket to the related program, entitlement, or payment record.
+
+## Integration
+
+- **spp_grm:** Extends `spp.grm.ticket` with program-related fields and onchange logic.
+- **spp_programs:** Links to `spp.program`, `spp.program.membership`, `spp.cycle`, `spp.entitlement`, and `spp.payment` models.
+- **Auto-install:** This module auto-installs when both `spp_grm` and `spp_programs` are present.

--- a/docs/reference/modules/spp_grm_registry.md
+++ b/docs/reference/modules/spp_grm_registry.md
@@ -1,0 +1,74 @@
+---
+openspp:
+  doc_status: draft
+---
+
+# Registry Integration
+
+**Module:** `spp_grm_registry`
+
+## Overview
+
+Link GRM tickets to OpenSPP registry (registrants)
+
+## Purpose
+
+This module is designed to:
+
+- **Link GRM tickets to registrants:** Associate grievance tickets with individual registrants, their households, and geographic areas from the OpenSPP registry.
+- **Detect repeat tickets:** Automatically identify when a registrant has filed multiple tickets within the last six months.
+- **Display ticket history on registrant profiles:** Show GRM ticket counts and actions on registrant and household partner records.
+
+## Module Dependencies
+
+| Dependency | Purpose |
+| --- | --- |
+| `spp_security` | Central security definitions for OpenSPP modules |
+| `spp_grm` | Provides a centralized Grievance Redress Mechanism for re... |
+| `spp_registry` | Consolidated registry management for individuals, groups,... |
+
+## Key Features
+
+### Registry Fields on Tickets
+
+The module adds the following fields to `spp.grm.ticket`:
+
+| Field | Description |
+| --- | --- |
+| Registrant | Individual registrant filing the complaint (filtered by household) |
+| Household | Household group related to the complaint |
+| Geographic Area | Area of the registrant |
+
+When a registrant is selected, the ticket's `partner_id` and `area_id` are automatically populated. Changing the household clears the registrant selection.
+
+### Repeat Ticket Detection
+
+The module automatically computes repeat ticket information for each ticket:
+
+| Field | Description |
+| --- | --- |
+| Repeat Count | Number of tickets from the same registrant in the last 6 months |
+| Is Repeat | Boolean flag indicating whether this is a repeat ticket |
+| Previous Tickets | Links to the registrant's other recent tickets |
+
+A "View Previous Tickets" action allows quick navigation to the registrant's ticket history.
+
+### Registrant Profile Extension
+
+The module extends `res.partner` with GRM ticket tracking:
+
+| Field | Description |
+| --- | --- |
+| GRM Tickets (Registrant) | All tickets where this partner is the registrant |
+| Total GRM Tickets | Count of all tickets filed by this registrant |
+| Open GRM Tickets | Count of currently open tickets |
+| GRM Tickets (Household) | All tickets related to this household |
+| Household GRM Tickets | Count of household-level tickets |
+
+Smart buttons on the partner form allow viewing tickets as either registrant or household.
+
+## Integration
+
+- **spp_grm:** Extends `spp.grm.ticket` with registrant, household, and area fields plus repeat detection.
+- **spp_registry:** Uses `res.partner` with `is_registrant` and `is_group` domain filters, and reads `area_id` and `individual_membership_ids` for auto-fill.
+- **Auto-install:** This module auto-installs when both `spp_grm` and `spp_registry` are present.

--- a/docs/reference/modules/spp_hazard.md
+++ b/docs/reference/modules/spp_hazard.md
@@ -1,0 +1,108 @@
+---
+openspp:
+  doc_status: draft
+---
+
+# Hazard & Emergency Management
+
+**Module:** `spp_hazard`
+
+## Overview
+
+Provides hazard classification, incident recording, and impact assessment for emergency response. Links registrants to disaster events with geographic scope and severity tracking to enable targeted humanitarian assistance.
+
+## Purpose
+
+This module is designed to:
+
+- **Classify hazard types:** Organize hazards in a hierarchical category tree (e.g., Natural > Storm > Typhoon) for standardized incident categorization.
+- **Record hazard incidents:** Track specific disaster events with temporal scope, geographic areas, severity levels, and lifecycle status.
+- **Assess impact on registrants:** Record how individual registrants are affected by incidents, including damage level, impact type, and verification status.
+- **Identify affected populations:** Find registrants located in areas affected by an incident for targeted humanitarian response.
+
+## Module Dependencies
+
+| Dependency | Purpose |
+| --- | --- |
+| `base` | Odoo core framework |
+| `spp_security` | Central security definitions for OpenSPP modules |
+| `spp_registry` | Consolidated registry management for individuals, groups,... |
+| `spp_area` | Establishes direct associations between OpenSPP registran... |
+| `spp_gis` | GIS core plus area geo fields and importer extensions (po... |
+
+## Key Features
+
+### Hazard Categories
+
+Categories (`spp.hazard.category`) organize hazard types in a parent-child hierarchy with computed full path names (e.g., "Natural > Storm > Typhoon").
+
+| Field | Description |
+| --- | --- |
+| Name / Code | Category identifier (code must be unique) |
+| Parent Category | Parent in the hierarchy |
+| Subcategories | Child categories |
+| Incident Count | Number of incidents using this category |
+
+### Hazard Incidents
+
+Incidents (`spp.hazard.incident`) represent specific disaster events with lifecycle tracking.
+
+| Field | Description |
+| --- | --- |
+| Name / Code | Incident identifier (e.g., "Typhoon Yolanda") |
+| Category | Hazard category classification |
+| Start Date / End Date | Temporal scope (end date empty if ongoing) |
+| Status | Alert, Active, Recovery, or Closed |
+| Severity | Level 1 (Minor) through Level 5 (Catastrophic) |
+| Affected Areas | Geographic areas impacted by the incident |
+| Area Details | Per-area severity overrides, notes, and population estimates |
+
+Incidents can identify potentially affected registrants by searching for all registrants located in the affected areas.
+
+### Impact Types
+
+Impact types (`spp.hazard.impact.type`) classify how registrants are affected. Each type belongs to a category: Physical, Economic, Health, or Social. Pre-installed types include Displacement, Property Damage, Livelihood Loss, Injury, and others.
+
+### Hazard Impacts
+
+Impact records (`spp.hazard.impact`) document how a specific registrant was affected by an incident.
+
+| Field | Description |
+| --- | --- |
+| Incident | The hazard event |
+| Registrant | The affected registrant |
+| Impact Type | Classification of the impact |
+| Damage Level | Minimal, Moderate, Severe, Critical, Partially Damaged, or Totally Damaged |
+| Impact Date | Date when the impact occurred |
+| Verification Status | Reported, Verified, Disputed, or Closed |
+| Verified By / Date | User and timestamp of verification |
+
+A `bulk_create_impacts` utility method creates impact records for all registrants in a given area, processing in batches of 500 and skipping duplicates.
+
+### Registrant Extensions
+
+The module extends `res.partner` with hazard impact tracking:
+
+| Field | Description |
+| --- | --- |
+| Hazard Impacts | All impact records for this registrant |
+| Impact Count | Total number of impact records |
+| Has Active Impact | Whether the registrant has an impact from an active/alert/recovery incident |
+
+### Geofence Extension
+
+The module adds a "Hazard Zone" geofence type and an optional link to a hazard incident on geofence records.
+
+## Integration
+
+- **spp_registry:** Extends `res.partner` with impact tracking fields and the ability to query impact history.
+- **spp_area:** Links incidents to geographic areas and uses area-based registrant lookup for affected population identification.
+- **spp_gis:** Extends `spp.gis.geofence` with the "Hazard Zone" type and incident linkage.
+- **mail:** Uses `mail.thread` and `mail.activity.mixin` on incidents and impacts for audit trail tracking.
+
+```{toctree}
+:maxdepth: 1
+:hidden:
+
+spp_hazard_programs
+```

--- a/docs/reference/modules/spp_hazard_programs.md
+++ b/docs/reference/modules/spp_hazard_programs.md
@@ -1,0 +1,53 @@
+---
+openspp:
+  doc_status: draft
+---
+
+# Programs Integration
+
+**Module:** `spp_hazard_programs`
+
+## Overview
+
+Links hazard impacts to program eligibility and entitlements. Enables emergency programs to use hazard data for targeting and benefit calculation.
+
+## Purpose
+
+This module is designed to:
+
+- **Link programs to hazard incidents:** Associate social protection programs with the disaster incidents they respond to, enabling emergency-mode operations.
+- **Determine emergency eligibility:** Identify registrants eligible for a program based on verified hazard impacts and qualifying damage levels.
+- **Track response programs per incident:** View which programs are responding to a given incident and how many registrants are potentially affected.
+
+## Module Dependencies
+
+| Dependency | Purpose |
+| --- | --- |
+| `spp_hazard` | Provides hazard classification, incident recording, and i... |
+| `spp_programs` | Manage cash and in-kind entitlements, integrate with inve... |
+
+## Key Features
+
+### Program Extension
+
+The module adds the following fields to `spp.program`:
+
+| Field | Description |
+| --- | --- |
+| Target Incidents | Hazard incidents this program responds to |
+| Is Emergency Program | Computed; true if any target incident is in alert, active, or recovery status |
+| Qualifying Damage Levels | Minimum damage level for eligibility: Any, Moderate and Above, Severe and Above, or Critical/Totally Damaged Only |
+| Emergency Mode | When enabled, relaxed compliance rules apply |
+| Potentially Affected Registrants | Computed count of registrants with verified impacts meeting the damage threshold |
+
+The `get_emergency_eligible_registrants` method returns all registrants who have verified impacts from the program's target incidents and meet the qualifying damage level threshold.
+
+### Incident Extension
+
+Incidents gain a `Response Programs` field showing which programs are linked, along with a program count and a navigation action to view those programs.
+
+## Integration
+
+- **spp_hazard:** Extends `spp.hazard.incident` with a many-to-many link to programs. Reads `spp.hazard.impact` records to compute eligible registrants based on verification status and damage level.
+- **spp_programs:** Extends `spp.program` with emergency response fields, damage level thresholds, and registrant eligibility queries.
+- **Auto-install:** This module auto-installs when both `spp_hazard` and `spp_programs` are present.

--- a/docs/reference/modules/spp_hide_menus_base.md
+++ b/docs/reference/modules/spp_hide_menus_base.md
@@ -22,10 +22,10 @@ This module is designed to:
 
 ## Module Dependencies
 
-| Dependency       | Description                            |
-| ---------------- | -------------------------------------- |
-| **base**         | Odoo core menu system                  |
-| **spp_security** | OpenSPP security groups and privileges |
+| Dependency | Purpose |
+| --- | --- |
+| `base` | Odoo core framework |
+| `spp_security` | Central security definitions for OpenSPP modules |
 
 ## Key Features
 

--- a/docs/reference/modules/spp_hxl.md
+++ b/docs/reference/modules/spp_hxl.md
@@ -1,0 +1,90 @@
+---
+openspp:
+  doc_status: draft
+---
+
+# HXL Integration
+
+**Module:** `spp_hxl`
+
+## Overview
+
+Humanitarian Exchange Language (HXL) support for data interoperability. Adds HXL hashtag mapping to variables and export profiles for humanitarian coordination.
+
+## Purpose
+
+This module is designed to:
+
+- **Manage HXL hashtags:** Maintain a registry of HXL 1.1 standard and custom hashtags organized by category (geographic, population, indicator, etc.) with format validation.
+- **Manage HXL attributes:** Maintain a registry of HXL attributes (e.g., `+f`, `+children`, `+code`) with category classification and format validation.
+- **Configure export profiles:** Define reusable export templates that map Odoo model fields to HXL-tagged columns for humanitarian data exchange.
+- **Map CEL variables to HXL tags:** Extend CEL variables with HXL hashtag and attribute mappings, controlling import and export behavior per variable.
+
+## Module Dependencies
+
+| Dependency | Purpose |
+| --- | --- |
+| `spp_security` | Central security definitions for OpenSPP modules |
+| `spp_cel_domain` | Write simple CEL-like expressions to filter records (Open... |
+| `spp_studio` | No-code customization interface for OpenSPP |
+| `spp_vocabulary` | OpenSPP: Vocabulary |
+
+## Key Features
+
+### HXL Hashtag Registry
+
+Stores HXL hashtags with metadata for data interoperability.
+
+| Field | Description |
+| --- | --- |
+| Hashtag | HXL hashtag string (e.g., `#affected`), must start with `#` |
+| Category | Classification such as Geographic, Population, Indicators, OpenSPP Custom |
+| Data Type | Expected data type: Text, Number, Date, or Geographic |
+| Is Standard | Whether the tag is part of the HXL 1.1 specification |
+
+### HXL Attribute Registry
+
+Stores HXL attributes that modify hashtags.
+
+| Field | Description |
+| --- | --- |
+| Code | Attribute code (e.g., `+f`, `+children`), must start with `+` |
+| Category | Classification such as Gender, Age Group, Data Type, Vocabulary Reference |
+| Is Standard | Whether the attribute is part of the HXL 1.1 specification |
+
+### Export Profiles
+
+Pre-configured export templates that map model fields to HXL-tagged columns.
+
+| Field | Description |
+| --- | --- |
+| Model | Target Odoo model for the export |
+| Columns | Ordered list of column definitions with field paths and HXL tags |
+| Include HXL Row | Whether to include the HXL hashtag row in exported files |
+| Date Format | Python strftime format for date columns |
+
+Each column can specify an HXL tag manually or build one by selecting a hashtag and combining it with attributes. The computed tag is stored for use during export.
+
+### CEL Variable HXL Mapping
+
+Extends CEL variables with HXL interoperability fields:
+
+| Field | Description |
+| --- | --- |
+| HXL Hashtag | Primary HXL hashtag for the variable |
+| HXL Attributes | Attribute string appended to the hashtag |
+| HXL Import Action | How to handle during import: map to field, create event, store as variable, or skip |
+| Include in HXL Export | Whether to include the variable in HXL-tagged exports |
+
+## Integration
+
+- **spp_cel_domain:** Extends CEL variables (`spp.cel.variable`) with HXL mapping fields for import/export behavior.
+- **spp_studio:** Provides the configuration UI context for managing HXL tags and profiles.
+- **spp_hxl_area:** This module's hashtag and attribute registries are used by `spp_hxl_area` for area-level HXL data import and aggregation.
+
+```{toctree}
+:maxdepth: 1
+:hidden:
+
+spp_hxl_area
+```

--- a/docs/reference/modules/spp_hxl_area.md
+++ b/docs/reference/modules/spp_hxl_area.md
@@ -1,0 +1,104 @@
+---
+openspp:
+  doc_status: draft
+---
+
+# Area Integration
+
+**Module:** `spp_hxl_area`
+
+## Overview
+
+HXL import with area-level aggregation for humanitarian indicators. Import HXL-tagged field data and aggregate to area-level metrics for coordination.
+
+## Purpose
+
+This module is designed to:
+
+- **Import HXL-tagged data:** Parse HXL-tagged CSV/Excel files using the `libhxl` library, auto-detect columns, and map them to area identifiers and aggregation targets.
+- **Match data to geographic areas:** Resolve imported rows to `spp.area` records using configurable strategies (P-code, name, GPS coordinates, or fuzzy name matching).
+- **Aggregate to area-level indicators:** Apply configurable aggregation rules (count, sum, average, min, max, percentage) to produce per-area indicator values.
+- **Sync indicators for CEL expressions:** Automatically write aggregated values to `spp.data.value` so they can be used in CEL eligibility criteria and other expressions.
+
+## Module Dependencies
+
+| Dependency | Purpose |
+| --- | --- |
+| `spp_hxl` | Humanitarian Exchange Language (HXL) support for data int... |
+| `spp_area` | Establishes direct associations between OpenSPP registran... |
+| `spp_cel_domain` | Write simple CEL-like expressions to filter records (Open... |
+| `spp_hazard` | Provides hazard classification, incident recording, and i... |
+| `spp_security` | Central security definitions for OpenSPP modules |
+| `job_worker` | Background job worker |
+
+### External Dependencies
+
+| Package | Purpose |
+| --- | --- |
+| `libhxl` | Python library for parsing and validating HXL-tagged data files |
+
+## Key Features
+
+### Import Profiles
+
+Reusable configurations that define how HXL data maps to areas and what aggregations to perform.
+
+| Field | Description |
+| --- | --- |
+| Area Matching Strategy | How to match rows to areas: P-code, Name, GPS, or Fuzzy Name |
+| Area Column HXL Tag | HXL tag identifying the area column (e.g., `#adm2+pcode`) |
+| Target Admin Level | Administrative level for area matching |
+| Latitude/Longitude Tags | HXL tags for GPS-based matching |
+| Default Incident | Optionally link all imported data to a hazard incident |
+
+### Aggregation Rules
+
+Define how to transform raw HXL data into area-level indicators.
+
+| Field | Description |
+| --- | --- |
+| Aggregation Type | Count, Sum, Average, Min, Max, Count Distinct, or Percentage |
+| Source Column HXL Tag | Which HXL column to aggregate |
+| Filter Expression | Python expression to filter rows before aggregation |
+| Target Variable | CEL variable to store the result |
+| Disaggregate By | Comma-separated HXL attributes for disaggregation (e.g., `+f,+m`) |
+| Output HXL Tag | HXL tag for re-exporting the aggregated indicator |
+
+### Import Batches
+
+Track individual import executions with full audit trail.
+
+| Field | Description |
+| --- | --- |
+| State | Draft, Columns Mapped, Processing, Completed, or Failed |
+| Statistics | Total rows, matched rows, unmatched rows, areas updated, indicators created |
+| Column Mappings | Auto-detected mappings with confidence scores, adjustable before processing |
+| Error Log | Detailed error information if the import fails |
+
+Import processing runs asynchronously via the job queue.
+
+### Area Indicators
+
+Stores aggregated indicator values per area with support for:
+
+- Period-based tracking (e.g., monthly snapshots)
+- Incident/disaster event linking
+- JSON-based disaggregation storage
+- Automatic sync to `spp.data.value` for CEL expression access
+
+### Import Wizard
+
+A guided wizard for importing HXL data that provides:
+
+- File upload with automatic HXL column detection
+- Data preview showing the first rows
+- Area matching preview with match/unmatch counts
+- List of unmatched area values for troubleshooting
+
+## Integration
+
+- **spp_hxl:** Uses the HXL hashtag and attribute registries for column detection and tag matching.
+- **spp_area:** Matches imported data rows to geographic areas using P-code, name, or GPS strategies.
+- **spp_hazard:** Links imported data to hazard incidents for disaster response coordination.
+- **spp_cel_domain:** Syncs aggregated indicators to `spp.data.value` so area-level metrics are available in CEL expressions for eligibility criteria.
+- **job_worker:** Runs import processing asynchronously in the background to handle large files.

--- a/docs/reference/modules/spp_import_match.md
+++ b/docs/reference/modules/spp_import_match.md
@@ -1,0 +1,73 @@
+---
+openspp:
+  doc_status: draft
+---
+
+# Import Match
+
+**Module:** `spp_import_match`
+
+## Overview
+
+OpenSPP Import Match enhances data import processes by intelligently matching incoming records against existing data, preventing duplication and ensuring registry integrity. It provides configurable matching logic and supports seamless updates to existing records during bulk data onboarding.
+
+## Purpose
+
+This module is designed to:
+
+- **Define match rules:** Configure which fields to use for detecting duplicate records during data import, with support for relational sub-fields and conditional matching.
+- **Prevent duplicate records:** Automatically find existing records that match incoming import rows, skipping or overwriting them based on configuration.
+- **Support asynchronous imports:** Split large import files into chunks and process them via background jobs to avoid timeouts.
+
+## Module Dependencies
+
+| Dependency | Purpose |
+| --- | --- |
+| `base` | Odoo core framework |
+| `spp_base_common` | The OpenSPP base module that provides the main menu, gene... |
+| `base_import` | Data import framework |
+| `job_worker` | Background job worker |
+| `spp_security` | Central security definitions for OpenSPP modules |
+
+## Key Features
+
+### Import Match Rules
+
+Configurable rules that define how to identify existing records during import.
+
+| Field | Description |
+| --- | --- |
+| Model | The Odoo model to apply matching against |
+| Fields | One or more fields to match on (combined as AND conditions) |
+| Sub-Field | For relational fields, a sub-field to match (e.g., `id_type_id/name`) |
+| Overwrite Match | When enabled, matched records are updated with imported values instead of skipped |
+| Is Conditional | When enabled, the field match only applies if the imported value equals a specified condition value |
+
+Multiple match rules can be defined per model. The system evaluates each rule in sequence order and returns the first single match found. If multiple records match a single rule, a validation error is raised.
+
+### Duplicate Detection During Import
+
+The module overrides the base `load()` method to intercept import operations:
+
+1. Converts imported rows into Odoo field values
+2. For each row, checks if an existing record matches using the configured rules
+3. Based on the match result:
+   - **No match:** Creates a new record
+   - **Match found + overwrite disabled:** Skips the row
+   - **Match found + overwrite enabled:** Updates the existing record
+4. Returns counts of created, skipped, and overwritten records
+
+### Asynchronous Import
+
+For imports exceeding 100 rows, the module automatically:
+
+1. Creates a CSV attachment from the parsed data
+2. Splits the data into chunks on record boundaries
+3. Queues each chunk as a separate background job with incremental priority
+4. Each chunk is processed independently via the job queue
+
+## Integration
+
+- **base_import:** Extends the standard Odoo import wizard (`base_import.import`) to add match rule selection and asynchronous chunked processing.
+- **job_worker:** Uses the job queue for processing large imports asynchronously, with each chunk running as a separate queued job.
+- **All models:** The `base` model override applies matching logic to any model import when match rules are configured and selected via the import UI context.

--- a/docs/reference/modules/spp_indicator.md
+++ b/docs/reference/modules/spp_indicator.md
@@ -1,0 +1,85 @@
+---
+openspp:
+  doc_status: draft
+---
+
+# Indicator
+
+**Module:** `spp_indicator`
+
+## Overview
+
+Publishable indicators based on CEL variables for dashboards, GIS, and APIs
+
+## Purpose
+
+This module is designed to:
+
+- **Publish indicators from CEL variables:** Link CEL variable computations to named, categorized indicators that can be selectively published to GIS, dashboards, APIs, and reports.
+- **Protect privacy with small cell suppression:** Apply k-anonymity-based suppression to prevent re-identification of individuals when indicator counts fall below configurable thresholds.
+- **Configure context-specific presentation:** Override indicator labels, formats, grouping, icons, and privacy thresholds per publication context (GIS, dashboard, API, report).
+
+## Module Dependencies
+
+| Dependency | Purpose |
+| --- | --- |
+| `spp_metric` | Unified metric foundation for indicators and simulations |
+| `spp_metric_service` | Computation services for fairness, distribution, breakdow... |
+| `spp_cel_domain` | Write simple CEL-like expressions to filter records (Open... |
+| `spp_security` | Central security definitions for OpenSPP modules |
+
+## Key Features
+
+### Indicator Definition
+
+Each indicator links a CEL variable to a publishable metric with presentation settings.
+
+| Field | Description |
+| --- | --- |
+| Name | Technical identifier in snake_case (e.g., `children_under_5`) |
+| Label | Human-readable display label (translatable) |
+| Variable | CEL variable that provides the computation (must be aggregate, computed, or field type) |
+| Format | Aggregation/display format: Count, Sum, Average, Percentage, Ratio, or Currency |
+| Category | Metric category for organizing indicators in displays |
+| Unit | Unit of measurement (e.g., people, households, %) |
+
+### Publication Channels
+
+Each indicator can be independently toggled for publication to:
+
+| Channel | Description |
+| --- | --- |
+| GIS | Available in GIS/QGIS spatial queries |
+| Dashboard | Available in dashboard widgets |
+| API | Available in external API responses |
+| Reports | Available in reports and exports |
+
+### Privacy Protection (k-Anonymity)
+
+Indicators enforce small cell suppression to protect individual privacy.
+
+| Field | Description |
+| --- | --- |
+| Minimum Count (k) | Suppress values when the underlying count is below this threshold (default: 5) |
+| Suppression Display | How to show suppressed values: Null/Empty, `*` (Suppressed), or `< [threshold]` |
+| Sensitive Data | Flag for sensitive attributes (disability, health) warranting higher thresholds |
+
+### Context-Specific Configuration
+
+Each indicator can have per-context overrides for different publication channels.
+
+| Field | Description |
+| --- | --- |
+| Context | GIS, Dashboard, API, or Report |
+| Label Override | Different label for this context |
+| Format Override | Different format for this context |
+| Minimum Count Override | Higher or lower privacy threshold per context |
+| GIS Threshold Mode | Color threshold calculation: Quartiles, Equal Intervals, Natural Breaks, or Manual |
+| Dashboard Widget Type | Widget style: Number, Gauge, or Chart |
+
+## Integration
+
+- **spp_metric:** Inherits the `spp.metric.base` abstract model for shared identity, presentation, and categorization fields.
+- **spp_metric_service:** Delegates privacy suppression to the `spp.metric.privacy` service for unified k-anonymity enforcement.
+- **spp_cel_domain:** Sources indicator computations from CEL variables, which define the underlying data queries and expressions.
+- **spp_indicator_studio:** Provides the Studio UI for managing indicators (views, menus, and actions).

--- a/docs/reference/modules/spp_indicator_studio.md
+++ b/docs/reference/modules/spp_indicator_studio.md
@@ -1,0 +1,60 @@
+---
+openspp:
+  doc_status: draft
+---
+
+# Indicator Studio
+
+**Module:** `spp_indicator_studio`
+
+## Overview
+
+Studio UI for managing publishable indicators
+
+## Purpose
+
+This module is designed to:
+
+- **Provide Studio UI for indicators:** Add list, form, kanban, and search views for managing publishable indicators within the OpenSPP Studio configuration interface.
+- **Manage indicator categories:** Expose metric category management under the Studio settings menu.
+
+## Module Dependencies
+
+| Dependency | Purpose |
+| --- | --- |
+| `spp_indicator` | Publishable indicators based on CEL variables for dashboa... |
+| `spp_studio` | No-code customization interface for OpenSPP |
+
+## Key Features
+
+### Indicator Management Views
+
+Provides a complete set of views for managing indicators:
+
+| View | Description |
+| --- | --- |
+| List | Sortable table showing name, label, variable, format, category, privacy settings, and publication toggles |
+| Form | Full editor with sections for identity, data source, presentation, publication channels, privacy (k-anonymity), and context overrides |
+| Kanban | Card view grouped by category, showing publication badges (GIS, Dashboard, API) |
+| Search | Filters by publication channel, sensitive data flag, and archived status; grouping by category, format, or source type |
+
+### Studio Menu Integration
+
+Adds indicator management under the Studio configuration menu:
+
+| Menu Item | Location |
+| --- | --- |
+| All Indicators | Studio > Settings > Indicators |
+| Categories | Studio > Settings > Indicators > Categories |
+
+Both menu items are restricted to users with the Studio Manager security group.
+
+### Auto-Install Behavior
+
+This is a bridge module that auto-installs when both `spp_indicator` and `spp_studio` are present. It contains no Python models of its own -- it provides only views, menus, and security access rules.
+
+## Integration
+
+- **spp_indicator:** Provides views and menu actions for the `spp.indicator` and `spp.indicator.context` models defined in this module.
+- **spp_studio:** Registers indicator menus under the Studio configuration hierarchy, using the Studio Manager security group for access control.
+- **spp_metric:** Exposes the `spp.metric.category` action for category management within the indicators menu.

--- a/docs/reference/modules/spp_irrigation.md
+++ b/docs/reference/modules/spp_irrigation.md
@@ -1,0 +1,62 @@
+---
+openspp:
+  doc_status: draft
+---
+
+# Irrigation
+
+**Module:** `spp_irrigation`
+
+## Overview
+
+Manages detailed irrigation assets by type, capacity, and unique identifiers, leveraging integrated GIS capabilities to map and display infrastructure locations and boundaries. The module models water distribution networks by defining and linking irrigation sources to destinations, providing critical data for strategic planning of resource allocation and infrastructure projects.
+
+## Purpose
+
+This module is designed to:
+
+- **Record irrigation assets:** Create and manage irrigation infrastructure records with type classification, capacity, and unique identifiers.
+- **Map infrastructure locations:** Store point coordinates and polygon boundaries for each irrigation asset using GIS fields.
+- **Model water distribution networks:** Define source-to-destination relationships between irrigation assets to represent water flow paths.
+
+## Module Dependencies
+
+| Dependency | Purpose |
+| --- | --- |
+| `base` | Odoo core framework |
+| `spp_gis` | GIS core plus area geo fields and importer extensions (po... |
+| `spp_security` | Central security definitions for OpenSPP modules |
+| `spp_registry` | Consolidated registry management for individuals, groups,... |
+| `spp_farmer_registry_vocabularies` | FAO-aligned vocabularies for farmer registry (crops, live... |
+
+## Key Features
+
+### Irrigation Asset Records
+
+Each irrigation asset captures infrastructure details linked to a farm.
+
+| Field | Description |
+| --- | --- |
+| Name/ID | Unique name or identifier for the irrigation asset |
+| Farm | Link to the farm (group registrant) that owns or uses this asset |
+| Asset Type | Vocabulary-based type from `urn:openspp:vocab:irrigation-asset-type` |
+| Total Capacity | Numeric capacity value for the asset |
+| Coordinates | GIS point location of the asset |
+| Geo Polygon | GIS polygon boundary of the asset |
+
+### Water Distribution Network
+
+Irrigation assets can be linked to model water flow:
+
+| Relationship | Description |
+| --- | --- |
+| Irrigation Sources | Other irrigation assets that supply water to this asset |
+| Irrigation Destinations | Other irrigation assets that receive water from this asset |
+
+Both relationships use many-to-many links, allowing complex distribution networks where a single source can feed multiple destinations and vice versa.
+
+## Integration
+
+- **spp_gis:** Uses `GeoPointField` and `GeoPolygonField` to store and display irrigation asset locations and boundaries on maps.
+- **spp_registry:** Links irrigation assets to farm registrants (group partners) for ownership tracking.
+- **spp_farmer_registry_vocabularies:** Uses the irrigation asset type vocabulary for standardized infrastructure classification.

--- a/docs/reference/modules/spp_key_management.md
+++ b/docs/reference/modules/spp_key_management.md
@@ -22,16 +22,17 @@ This module is designed to:
 
 ## Module Dependencies
 
-| Dependency       | Description                |
-| ---------------- | -------------------------- |
-| **base**         | Core Odoo framework        |
-| **spp_security** | OpenSPP security framework |
+| Dependency | Purpose |
+| --- | --- |
+| `base` | Odoo core framework |
+| `spp_security` | Central security definitions for OpenSPP modules |
 
-### External Python Dependencies
+### External Dependencies
 
-| Package          | Description                          |
-| ---------------- | ------------------------------------ |
-| **cryptography** | Cryptographic primitives and recipes |
+| Package | Purpose |
+| --- | --- |
+| `cryptography` | |
+| `jwcrypto` | |
 
 ## Key Features
 
@@ -138,25 +139,3 @@ Use the "Test Connection" action on the provider registry to verify:
 - Key material is never logged or exposed in error messages
 - Access to key management is restricted to system administrators
 - Connection status helps identify configuration issues
-
-## Technical Details
-
-### Abstract Provider Interface
-
-All providers implement the `spp.key.provider` abstract model with:
-
-| Method                          | Description                          |
-| ------------------------------- | ------------------------------------ |
-| `get_data_key(key_id, version)` | Retrieve encryption key material     |
-| `get_index_salt(purpose)`       | Get salt for blind index computation |
-| `rotate_key(key_id)`            | Create new key version               |
-| `list_key_versions(key_id)`     | List available versions              |
-| `test_connection()`             | Verify backend connectivity          |
-
-### Signature Utilities
-
-The module includes utilities for digital signatures in `utils/signature.py`, supporting:
-
-- Key pair generation
-- Message signing
-- Signature verification

--- a/docs/reference/modules/spp_land_record.md
+++ b/docs/reference/modules/spp_land_record.md
@@ -1,0 +1,73 @@
+---
+openspp:
+  doc_status: draft
+---
+
+# Land Record
+
+**Module:** `spp_land_record`
+
+## Overview
+
+The OpenSPP Land Record module digitizes and centralizes land parcel information, linking it to associated farms, ownership details, and lease agreements. It captures and displays geographical boundaries and coordinates on interactive maps, supporting land use classification and program planning.
+
+## Purpose
+
+This module is designed to:
+
+- **Record land parcels:** Create and manage land parcel records with acreage, land use classification, and unique identifiers linked to farms.
+- **Track ownership and leases:** Associate land parcels with owners and lessees, including lease start and end date tracking with validation.
+- **Map parcel boundaries:** Store point coordinates and polygon boundaries for each parcel using GIS fields.
+- **Export as GeoJSON:** Generate GeoJSON representations of land records with coordinate projection support for mapping applications.
+
+## Module Dependencies
+
+| Dependency | Purpose |
+| --- | --- |
+| `base` | Odoo core framework |
+| `spp_base_common` | The OpenSPP base module that provides the main menu, gene... |
+| `spp_gis` | GIS core plus area geo fields and importer extensions (po... |
+| `spp_registry` | Consolidated registry management for individuals, groups,... |
+| `spp_security` | Central security definitions for OpenSPP modules |
+| `spp_farmer_registry_vocabularies` | FAO-aligned vocabularies for farmer registry (crops, live... |
+
+## Key Features
+
+### Land Parcel Records
+
+Each land record captures parcel information linked to a farm.
+
+| Field | Description |
+| --- | --- |
+| Parcel Name/ID | Unique name or identifier for the land parcel |
+| Farm | Link to the farm partner that this parcel belongs to |
+| Acreage | Area measurement of the parcel |
+| Land Use | Vocabulary-based classification from `urn:openspp:vocab:land-use` |
+| Coordinates | GIS point location of the parcel |
+| Land Polygons | GIS polygon boundary of the parcel |
+
+### Ownership and Lease Tracking
+
+| Field | Description |
+| --- | --- |
+| Owner | Partner record representing the parcel owner |
+| Lessee | Partner record representing the current lessee |
+| Lease Start | Start date of the lease agreement |
+| Lease End | End date of the lease agreement (validated to be after start date) |
+
+The module validates that lease end dates cannot precede lease start dates, with both server-side constraints and client-side warnings on date changes.
+
+### GeoJSON Export
+
+The `get_geojson()` method generates a GeoJSON FeatureCollection from land records with:
+
+- Configurable geometry type filtering (point, polygon, or all)
+- Coordinate reprojection between spatial reference systems (default: EPSG:3857 to EPSG:4326)
+- Feature properties including parcel name, land use, and acreage
+
+## Integration
+
+- **spp_gis:** Uses `GeoPointField` and `GeoPolygonField` to store and display parcel locations and boundaries on interactive maps.
+- **spp_registry:** Links land records to farm and owner/lessee partner records.
+- **spp_farmer_registry_vocabularies:** Uses the land use vocabulary for standardized parcel classification.
+- **mail.thread:** Inherits message tracking for audit trail on land record changes.

--- a/docs/reference/modules/spp_metric.md
+++ b/docs/reference/modules/spp_metric.md
@@ -1,0 +1,64 @@
+---
+openspp:
+  doc_status: draft
+---
+
+# Metric
+
+**Module:** `spp_metric`
+
+## Overview
+
+Unified metric foundation for indicators and simulations
+
+## Purpose
+
+This module is designed to:
+
+- **Provide a shared metric foundation:** Define an abstract base model with common fields (identity, presentation, categorization) that concrete metric types inherit to avoid field duplication.
+- **Manage metric categories:** Maintain a hierarchical category system for organizing all metric types in displays and reports.
+
+## Module Dependencies
+
+| Dependency | Purpose |
+| --- | --- |
+| `base` | Odoo core framework |
+
+## Key Features
+
+### Metric Base Model
+
+An abstract model (`spp.metric.base`) that provides shared fields inherited by concrete metric types such as indicators and simulation metrics.
+
+| Field | Description |
+| --- | --- |
+| Name | Technical identifier (e.g., `children_under_5`) |
+| Label | Human-readable display label (translatable) |
+| Description | Detailed description of what the metric measures |
+| Unit | Unit of measurement (e.g., people, USD, %) |
+| Decimal Places | Number of decimal places for display |
+| Category | Link to a metric category for organization |
+| Sequence | Display order within a category |
+| Active | Toggle to hide inactive metrics |
+
+Concrete models inherit this abstract model and add their own type-specific fields. For example, `spp.indicator` adds publication flags and privacy settings, while simulation metrics add CEL expressions and aggregation types.
+
+### Metric Categories
+
+A hierarchical categorization system for organizing metrics.
+
+| Field | Description |
+| --- | --- |
+| Name | Display name (e.g., Demographics), translatable |
+| Code | Unique technical identifier (e.g., `demographics`) |
+| Description | Description of what metrics belong in this category |
+| Parent Category | Optional parent for hierarchical organization |
+| Sequence | Display order |
+
+Categories enforce unique codes and prevent circular parent relationships.
+
+## Integration
+
+- **spp_indicator:** Inherits `spp.metric.base` for indicator identity, presentation, and categorization fields. Uses `spp.metric.category` for indicator grouping.
+- **spp_metric_service:** Provides the category model used by metric computation services for organizing breakdown and distribution results.
+- **spp_indicator_studio:** Exposes category management views within the Studio configuration interface.

--- a/docs/reference/modules/spp_metric_service.md
+++ b/docs/reference/modules/spp_metric_service.md
@@ -1,0 +1,98 @@
+---
+openspp:
+  doc_status: draft
+---
+
+# Metric Service
+
+**Module:** `spp_metric_service`
+
+## Overview
+
+Computation services for fairness, distribution, breakdown, and privacy
+
+## Purpose
+
+This module is designed to:
+
+- **Analyze targeting fairness:** Compute equity scores and disparity ratios across demographic groups to assess whether program targeting reaches different populations proportionally.
+- **Compute distribution statistics:** Calculate Gini coefficients, Lorenz curves, percentiles, and other inequality metrics from numerical value sets.
+- **Break down registrants by dimensions:** Categorize registrants by configurable demographic dimensions (gender, age group, disability, area, etc.) and compute per-group counts.
+- **Enforce privacy protections:** Apply k-anonymity with complementary suppression to prevent re-identification of individuals in small groups.
+- **Cache dimension evaluations:** Cache demographic dimension evaluation results for improved performance on repeated breakdown computations.
+
+## Module Dependencies
+
+| Dependency | Purpose |
+| --- | --- |
+| `base` | Odoo core framework |
+| `spp_cel_domain` | Write simple CEL-like expressions to filter records (Open... |
+| `spp_area` | Establishes direct associations between OpenSPP registran... |
+| `spp_registry` | Consolidated registry management for individuals, groups,... |
+
+## Key Features
+
+### Fairness Analysis Service
+
+Analyzes whether program targeting reaches demographic groups proportionally.
+
+| Output | Description |
+| --- | --- |
+| Equity Score | 0-100 score that decreases when disparities are detected |
+| Disparity Ratio | Per-group ratio of group coverage to overall coverage |
+| Status | `proportional`, `low_coverage`, or `under_represented` per group |
+| Overall Coverage | Ratio of beneficiaries to total population |
+
+The service supports field-based dimensions (Many2one, Selection, Boolean fields) using efficient `read_group` queries, and CEL expression-based dimensions for custom categorization logic.
+
+### Distribution Service
+
+Computes inequality and distribution statistics from a list of numerical values.
+
+| Metric | Description |
+| --- | --- |
+| Gini Coefficient | Inequality measure from 0.0 (perfect equality) to 1.0 (perfect inequality) |
+| Lorenz Deciles | Cumulative income share at each population decile |
+| Percentiles | P10, P25, P50 (median), P75, P90 values |
+| Basic Statistics | Count, total, minimum, maximum, mean, median, standard deviation |
+
+### Breakdown Service
+
+Categorizes registrants by one or more demographic dimensions and counts per combination.
+
+Results are keyed by pipe-separated dimension values (e.g., `male|urban`) with per-cell counts and human-readable labels. Uses the dimension cache service for performance.
+
+### Privacy Service
+
+Enforces k-anonymity with complementary suppression on aggregated results.
+
+| Feature | Description |
+| --- | --- |
+| Primary Suppression | Suppress cells with counts below the k threshold (default: 5) |
+| Complementary Suppression | Also suppress sibling cells to prevent derivation from marginal totals |
+| Dimension-Aware | Multi-dimensional suppression checks each dimension slice independently |
+| Display Modes | Suppressed values shown as null, `*`, or `< [threshold]` |
+| Access Levels | Strip individual record IDs from aggregate-level results |
+
+### Demographic Dimensions
+
+Configurable dimensions for group-by analysis.
+
+| Field | Description |
+| --- | --- |
+| Dimension Type | Field-based (direct field lookup) or CEL Expression (custom logic) |
+| Field Path | Dot-notation path for field-based dimensions (e.g., `gender_id.code`) |
+| CEL Expression | Expression returning a category value per registrant |
+| Label Mappings | JSON-based mapping from dimension values to display labels |
+| Default Value | Fallback value when evaluation returns nothing |
+
+### Dimension Cache
+
+Caches dimension evaluation results using Odoo's `ormcache` for performance improvement on repeated computations. Cache keys include the dimension ID, write date, and a hash of registrant IDs. Cache invalidates automatically when dimension configuration changes.
+
+## Integration
+
+- **spp_cel_domain:** Uses the CEL service to evaluate expression-based dimensions for custom categorization of registrants.
+- **spp_registry:** Queries `res.partner` registrant records for population baselines and demographic field lookups.
+- **spp_area:** Supports area-based demographic dimensions for geographic breakdowns.
+- **spp_indicator:** Provides the privacy suppression service (`spp.metric.privacy`) used by indicators for k-anonymity enforcement.

--- a/docs/reference/modules/spp_mis_demo_v2.md
+++ b/docs/reference/modules/spp_mis_demo_v2.md
@@ -22,20 +22,24 @@ This module is designed to:
 
 ## Module Dependencies
 
-| Dependency                | Description                                                           |
-| ------------------------- | --------------------------------------------------------------------- |
-| **spp_starter_sp_mis**    | Complete SP-MIS bundle with programs and service points               |
-| **spp_cr_types_advanced** | Advanced change request types (Add/Remove Member, Exit, Split, Merge) |
-| **spp_demo**              | Core demo data generator                                              |
-| **spp_gis_report**        | Geographic visualization for reports                                  |
-| **spp_claim_169**         | QR credentials for beneficiary verification                           |
+| Dependency | Purpose |
+| --- | --- |
+| `spp_starter_sp_mis` | Complete SP-MIS bundle with Social Registry, Programs, an... |
+| `spp_cr_types_advanced` | Advanced change request types with custom Python strategies |
+| `spp_demo` | Core demo module with data generator and sample data for ... |
+| `spp_gis_report` | Geographic visualization and reporting for social protect... |
+| `spp_registrant_gis` | Adds GPS coordinates to registrants for spatial queries |
+| `spp_indicator` | Publishable indicators based on CEL variables for dashboa... |
+| `spp_analytics` | Query engine for indicators, simulations, and GIS analytics |
+| `spp_studio` | No-code customization interface for OpenSPP |
+| `spp_api_v2_gis` | OGC API - Features compliant GIS endpoints for QGIS and G... |
+| `spp_claim_169` | MOSIP Claim 169 QR code identity credentials for registrants |
 
-### External Python Dependencies
+### External Dependencies
 
-| Package      | Description                           |
-| ------------ | ------------------------------------- |
-| **faker**    | Generates fake but realistic data     |
-| **requests** | HTTP client for external integrations |
+| Package | Purpose |
+| --- | --- |
+| `requests` | |
 
 ## Key Features
 

--- a/docs/reference/modules/spp_oauth.md
+++ b/docs/reference/modules/spp_oauth.md
@@ -1,0 +1,63 @@
+---
+openspp:
+  doc_status: draft
+---
+
+# API: Oauth
+
+**Module:** `spp_oauth`
+
+## Overview
+
+The module establishes an OAuth 2.0 authentication framework, securing OpenSPP API communication for integrated systems and applications.
+
+## Purpose
+
+This module is designed to:
+
+- **Manage RSA key pairs:** Store OAuth 2.0 RSA public and private keys in Odoo system parameters, configurable through the Settings UI.
+- **Sign JWT tokens:** Generate RS256-signed JSON Web Tokens using the configured private key for API authentication.
+- **Verify JWT tokens:** Decode and validate incoming JWT access tokens using the configured public key.
+
+## Module Dependencies
+
+| Dependency | Purpose |
+| --- | --- |
+| `spp_security` | Central security definitions for OpenSPP modules |
+| `base` | Odoo core framework |
+
+### External Dependencies
+
+| Package | Purpose |
+| --- | --- |
+| `pyjwt>=2.4.0` | JWT encoding, decoding, and verification |
+| `cryptography` | RSA key handling for RS256 algorithm support |
+
+## Key Features
+
+### RSA Key Configuration
+
+OAuth RSA keys are stored as Odoo system parameters and managed through Settings.
+
+| Parameter | Description |
+| --- | --- |
+| `spp_oauth.oauth_priv_key` | RSA private key for signing JWT tokens |
+| `spp_oauth.oauth_pub_key` | RSA public key for verifying JWT tokens |
+
+Both keys are configurable via the `res.config.settings` form in the Odoo Settings UI.
+
+### JWT Token Operations
+
+The module provides utility functions for JWT token management:
+
+| Function | Description |
+| --- | --- |
+| `calculate_signature` | Encodes a JWT with custom header and payload, signed with the RS256 algorithm |
+| `verify_and_decode_signature` | Verifies a JWT access token against the public key and returns the decoded payload |
+
+All JWT operations use the RS256 (RSA + SHA-256) algorithm. Key retrieval and token errors raise `OpenSPPOAuthJWTException` with automatic error logging.
+
+## Integration
+
+- **spp_api_v2:** Provides the JWT signing and verification infrastructure used by the OpenSPP API v2 token endpoint for OAuth 2.0 authentication.
+- **spp_security:** Inherits central security definitions for access control over key management.

--- a/docs/reference/modules/spp_programs.md
+++ b/docs/reference/modules/spp_programs.md
@@ -23,31 +23,32 @@ This module is designed to:
 
 ## Module Dependencies
 
-| Dependency           | Purpose                                       |
-| -------------------- | --------------------------------------------- |
-| `account`            | Accounting and fund management                |
-| `web`                | Web interface components                      |
-| `base`               | Odoo core framework                           |
-| `mail`               | Communication and notifications               |
-| `spp_registry`       | Beneficiary registry for enrollment           |
-| `spp_banking`        | Bank account management for payments          |
-| `calendar`           | Scheduling capabilities                       |
-| `product`            | Product catalog for in-kind items             |
-| `stock`              | Inventory management for in-kind distribution |
-| `spp_security`       | Security groups and access control            |
-| `spp_area`           | Geographic targeting                          |
-| `spp_service_points` | Distribution point management                 |
-| `spp_user_roles`     | Role-based access control                     |
-| `spp_base_common`    | OpenSPP main menu integration                 |
-| `spp_approval`       | Approval workflow management                  |
-| `spp_cel_domain`     | CEL expression for eligibility rules          |
-| `spp_cel_widget`     | CEL expression editor UI                      |
+| Dependency | Purpose |
+| --- | --- |
+| `account` | Accounting and invoicing |
+| `web` | Web interface components |
+| `base` | Odoo core framework |
+| `mail` | Communication and activity tracking |
+| `spp_registry` | Consolidated registry management for individuals, groups,... |
+| `spp_banking` | OpenSPP Banking: Bank Details |
+| `calendar` | Calendar and scheduling |
+| `product` | Product catalog management |
+| `stock` | Inventory and warehouse management |
+| `spp_security` | Central security definitions for OpenSPP modules |
+| `spp_area` | Establishes direct associations between OpenSPP registran... |
+| `spp_service_points` | The OpenSPP Service Points module manages physical or vir... |
+| `spp_user_roles` | The OpenSPP User Roles module defines and manages distinc... |
+| `spp_base_common` | The OpenSPP base module that provides the main menu, gene... |
+| `spp_approval` | Standardized approval workflows with multi-tier sequencin... |
+| `spp_cel_domain` | Write simple CEL-like expressions to filter records (Open... |
+| `spp_cel_widget` | Reusable CEL expression editor with syntax highlighting a... |
+| `job_worker` | Background job worker |
 
 ### External Dependencies
 
-| Package           | Purpose                       |
-| ----------------- | ----------------------------- |
-| `python-dateutil` | Date calculations and parsing |
+| Package | Purpose |
+| --- | --- |
+| `python-dateutil` | |
 
 ## Key Features
 
@@ -241,13 +242,3 @@ Expression-based configuration:
 | Assign       | Link to payment method/service point |
 | Disburse     | Execute payments                     |
 | Reconcile    | Record actual disbursements          |
-
-## Technical Details
-
-| Property       | Value          |
-| -------------- | -------------- |
-| Technical Name | `spp_programs` |
-| Category       | OpenSPP/Core   |
-| Version        | 19.0.2.0.0     |
-| License        | LGPL-3         |
-| Application    | Yes            |

--- a/docs/reference/modules/spp_registrant_gis.md
+++ b/docs/reference/modules/spp_registrant_gis.md
@@ -1,0 +1,41 @@
+---
+openspp:
+  doc_status: draft
+---
+
+# Registrant GIS
+
+**Module:** `spp_registrant_gis`
+
+## Overview
+
+Adds GPS coordinates to registrants for spatial queries
+
+## Purpose
+
+This module is designed to:
+
+- **Add GPS coordinates to registrants:** Extends each registrant record with a GeoPoint field for storing latitude/longitude coordinates.
+- **Enable spatial queries:** Allows proximity-based targeting and geographic analysis of registrant locations.
+
+## Module Dependencies
+
+| Dependency | Purpose |
+| --- | --- |
+| `spp_gis` | GIS core plus area geo fields and importer extensions (po... |
+| `spp_registry` | Consolidated registry management for individuals, groups,... |
+
+## Key Features
+
+### GPS Coordinates Field
+
+Adds a `coordinates` GeoPoint field to `res.partner` (registrant records). This field stores geographic coordinates (latitude/longitude) that can be used for:
+
+- Mapping registrant locations
+- Proximity-based targeting and filtering
+- Geographic analysis and reporting
+
+## Integration
+
+- **spp_gis:** Uses the GeoPoint field type provided by the GIS module for storing spatial data.
+- **spp_registry:** Extends the registrant model (`res.partner`) to include geographic coordinates alongside other registrant data.

--- a/docs/reference/modules/spp_registry.md
+++ b/docs/reference/modules/spp_registry.md
@@ -23,17 +23,23 @@ This module is designed to:
 
 ## Module Dependencies
 
-| Dependency         | Purpose                                |
-| ------------------ | -------------------------------------- |
-| `base`             | Odoo core framework                    |
-| `mail`             | Communication and activity tracking    |
-| `contacts`         | Base contact model extension           |
-| `web`              | Web interface components               |
-| `portal`           | Portal access capabilities             |
+| Dependency | Purpose |
+| --- | --- |
+| `base` | Odoo core framework |
+| `mail` | Communication and activity tracking |
+| `contacts` | Base contact model extension |
+| `web` | Web interface components |
+| `portal` | Portal access capabilities |
 | `phone_validation` | Phone number validation and formatting |
-| `spp_security`     | Security groups and access control     |
-| `spp_vocabulary`   | Vocabulary/lookup value management     |
-| `muk_web_chatter`  | Enhanced chatter positioning           |
+| `spp_security` | Central security definitions for OpenSPP modules |
+| `spp_vocabulary` | OpenSPP: Vocabulary |
+| `muk_web_chatter` | Enhanced chatter positioning |
+
+### External Dependencies
+
+| Package | Purpose |
+| --- | --- |
+| `python-magic` | |
 
 ## Key Features
 
@@ -151,19 +157,3 @@ The registry UI organizes information into logical tabs:
 | **Identity**      | ID documents, verification status      |
 | **Participation** | Group memberships, program enrollments |
 | **History**       | Activity log, change history           |
-
-## Technical Details
-
-| Property       | Value          |
-| -------------- | -------------- |
-| Technical Name | `spp_registry` |
-| Category       | OpenSPP/Core   |
-| Version        | 19.0.2.2.0     |
-| License        | LGPL-3         |
-| Application    | Yes            |
-
-### External Dependencies
-
-| Package        | Purpose                                  |
-| -------------- | ---------------------------------------- |
-| `python-magic` | File type detection for document uploads |

--- a/docs/reference/modules/spp_registry_group_hierarchy.md
+++ b/docs/reference/modules/spp_registry_group_hierarchy.md
@@ -1,0 +1,52 @@
+---
+openspp:
+  doc_status: draft
+---
+
+# Registry Group Hierarchy
+
+**Module:** `spp_registry_group_hierarchy`
+
+## Overview
+
+The module introduces hierarchical relationships among OpenSPP registry groups, enabling the creation of nested structures where groups can contain both individuals and other sub-groups. It extends g2p_registry_group and g2p_registry_membership modules.
+
+## Purpose
+
+This module is designed to:
+
+- **Enable group-of-groups structures:** Allow groups to contain both individuals and other groups as members, forming hierarchical relationships (e.g., cooperatives containing households).
+- **Control membership types per group type:** Use vocabulary codes to define which group types allow mixed membership (individuals and sub-groups).
+
+## Module Dependencies
+
+| Dependency | Purpose |
+| --- | --- |
+| `spp_security` | Central security definitions for OpenSPP modules |
+| `base` | Odoo core framework |
+| `spp_registry` | Consolidated registry management for individuals, groups,... |
+| `spp_vocabulary` | OpenSPP: Vocabulary |
+
+## Key Features
+
+### Allow All Member Types
+
+Adds an `allow_all_member_type` boolean to group type vocabulary codes (`spp.vocabulary.code`). When enabled on a group type, groups of that type can contain both individual registrants and other groups as members.
+
+### Dynamic Membership Domain
+
+Extends `spp.group.membership` with a computed domain that adjusts based on the group type:
+
+| Group Type Setting | Allowed Members |
+| --- | --- |
+| `allow_all_member_type` = False | Individual registrants only |
+| `allow_all_member_type` = True | Both individuals and groups (excluding the group itself) |
+
+### Member Form Navigation
+
+Provides an `open_member_form` action on membership records that opens the correct form view depending on whether the member is an individual or a group.
+
+## Integration
+
+- **spp_vocabulary:** Extends vocabulary codes with the `allow_all_member_type` flag to control which group types support hierarchical membership.
+- **spp_registry:** Extends group membership to support dynamic filtering of allowed members based on the parent group's type configuration.

--- a/docs/reference/modules/spp_registry_search.md
+++ b/docs/reference/modules/spp_registry_search.md
@@ -22,9 +22,9 @@ This module is designed to:
 
 ## Module Dependencies
 
-| Dependency       | Description                                            |
-| ---------------- | ------------------------------------------------------ |
-| **spp_registry** | Core registry functionality for individuals and groups |
+| Dependency | Purpose |
+| --- | --- |
+| `spp_registry` | Consolidated registry management for individuals, groups,... |
 
 ## Key Features
 

--- a/docs/reference/modules/spp_scoring.md
+++ b/docs/reference/modules/spp_scoring.md
@@ -1,0 +1,132 @@
+---
+openspp:
+  doc_status: draft
+---
+
+# Scoring
+
+**Module:** `spp_scoring`
+
+## Overview
+
+Configurable scoring and assessment framework for beneficiary targeting
+
+## Purpose
+
+This module is designed to:
+
+- **Define scoring models:** Create configurable scoring methodologies with indicators, weights, and thresholds for assessing registrants (e.g., Proxy Means Test, vulnerability index).
+- **Calculate scores:** Evaluate registrants against scoring models using a central engine that supports multiple calculation methods.
+- **Classify registrants:** Automatically assign classifications (e.g., "Extremely Poor", "Vulnerable") based on score thresholds.
+- **Process scores in batch:** Score large populations synchronously or asynchronously using job_worker for background processing.
+
+## Module Dependencies
+
+| Dependency | Purpose |
+| --- | --- |
+| `base` | Odoo core framework |
+| `mail` | Communication and activity tracking |
+| `spp_security` | Central security definitions for OpenSPP modules |
+| `spp_registry` | Consolidated registry management for individuals, groups,... |
+| `spp_cel_domain` | Write simple CEL-like expressions to filter records (Open... |
+| `spp_cel_widget` | Reusable CEL expression editor with syntax highlighting a... |
+| `job_worker` | Background job worker |
+
+## Key Features
+
+### Scoring Models
+
+A scoring model defines a complete scoring methodology. Each model has:
+
+| Field | Description |
+| --- | --- |
+| Name / Code | Human-readable name and unique identifier |
+| Category | Purpose classification: Poverty Assessment, Vulnerability Assessment, Eligibility Scoring, Triage/Prioritization, or Custom |
+| Calculation Method | How the total score is computed: Weighted Sum, CEL Formula, Lookup Table, External Service, or Custom Plugin |
+| Validity Period | Effective and end dates controlling when the model is active |
+| Strict Mode | When enabled, scoring fails if required indicators are missing |
+
+Models must pass validation (indicators exist, thresholds exist, weights sum correctly, CEL expressions compile) before they can be activated.
+
+### Indicators
+
+Each indicator defines a single scoring component:
+
+| Field | Description |
+| --- | --- |
+| Field Path | Dot-notation path to the registrant field (e.g., `household.roof_material`) |
+| Weight | Multiplier applied to the indicator score |
+| Calculation Type | Direct Value, Value Mapping, Range Mapping, CEL Formula, or Derived/Computed |
+| Default Handling | Default value and score when data is missing |
+| Min/Max Score | Constraints on the indicator score |
+
+### Value Mappings
+
+For mapped and range indicators, value mappings translate field values into scores:
+
+- **Exact mapping:** Maps specific values to scores (e.g., "concrete" = 5, "thatch" = 1)
+- **Range mapping:** Maps numeric ranges to scores (e.g., 0-2 hectares = 1, 2-5 hectares = 3)
+
+### Thresholds and Classifications
+
+Thresholds map score ranges to classification labels:
+
+| Field | Description |
+| --- | --- |
+| Min/Max Score | Inclusive score range for this classification |
+| Classification Code | Machine-readable code (e.g., `EXTREME_POOR`) |
+| Classification Label | Human-readable label (e.g., "Extremely Poor") |
+| Display Color | Visual color coding (red, orange, yellow, green, blue, purple, gray) |
+
+### Scoring Engine
+
+The central scoring engine (`spp.scoring.engine`) calculates scores:
+
+- Processes each indicator to extract field values and compute weighted scores
+- Supports CEL formula-based total score calculation
+- Captures a full breakdown with per-indicator contributions
+- Stores input snapshots for audit and reproducibility
+- Provides `get_or_calculate_score` to reuse recent scores within a configurable age
+
+### Batch Processing
+
+For scoring large populations:
+
+- Synchronous processing for datasets under 1,000 registrants
+- Asynchronous chunked processing via `job_worker` for larger datasets (chunks of 500)
+- Batch job tracking with progress counters (successful/failed counts)
+- Support for `fail_fast` mode to stop on first error
+
+### Scoring Results
+
+Each scoring result stores:
+
+- The calculated total score and classification
+- A JSON breakdown showing each indicator's contribution
+- An inputs snapshot capturing field values at calculation time
+- Metadata: calculation date, mode (manual/batch/automatic), model version
+- Per-indicator detail records for relational querying
+
+Performance indexes on `(registrant_id, model_id, calculation_date)` support efficient lookups at scale.
+
+### Data Integration
+
+When activated, scoring models automatically:
+
+- Create CEL variables (e.g., `pmt_2024_urban_score`) for use in targeting expressions
+- Cache scoring results in the unified data store (`spp.data.value`) for CEL access
+- Register as indicator providers so scores can be queried via `metric("scoring.<model_code>")`
+
+## Integration
+
+- **spp_cel_domain / spp_cel_widget:** CEL expressions can be used for indicator formulas and total score calculation. Score variables are accessible in CEL targeting expressions.
+- **job_worker:** Provides asynchronous batch scoring for large populations, with chunked processing and progress tracking.
+- **spp_registry:** Scores are calculated against registrant records (`res.partner`), reading field values via configurable field paths.
+- **spp_indicators (optional):** Scoring models register as indicator providers, making scores available via `metric()` in CEL expressions.
+
+```{toctree}
+:maxdepth: 1
+:hidden:
+
+spp_scoring_programs
+```

--- a/docs/reference/modules/spp_scoring_programs.md
+++ b/docs/reference/modules/spp_scoring_programs.md
@@ -1,0 +1,65 @@
+---
+openspp:
+  doc_status: draft
+---
+
+# Programs Bridge
+
+**Module:** `spp_scoring_programs`
+
+## Overview
+
+Integrates scoring with program eligibility and entitlements
+
+## Purpose
+
+This module is designed to:
+
+- **Use scoring for program eligibility:** Determine whether registrants qualify for a program based on their score or classification from a scoring model.
+- **Track scores on program membership:** Record the enrollment score and classification, and compute the latest score for each program member.
+- **Auto-score on enrollment:** Optionally calculate scores automatically when registrants are enrolled in a program.
+
+## Module Dependencies
+
+| Dependency | Purpose |
+| --- | --- |
+| `spp_scoring` | Configurable scoring and assessment framework for benefic... |
+| `spp_programs` | Manage cash and in-kind entitlements, integrate with inve... |
+
+## Key Features
+
+### Scoring-Based Eligibility
+
+Extends `spp.program` with scoring eligibility settings:
+
+| Field | Description |
+| --- | --- |
+| Scoring Model | Active scoring model used for eligibility checks |
+| Use Scoring for Eligibility | Enable/disable scoring-based eligibility on the program |
+| Minimum Score | Minimum score required for eligibility (inclusive) |
+| Maximum Score | Maximum score allowed for eligibility (inclusive) |
+| Required Classifications | Comma-separated classification codes that qualify (e.g., `POOR,EXTREME_POOR`) |
+| Auto-Score on Enrollment | Automatically calculate score when a registrant is enrolled |
+| Maximum Score Age (Days) | How old an existing score can be before recalculation (default: 180 days) |
+
+Eligibility can be checked by score range or by classification code. The module hooks into pre-enrollment validation to reject ineligible registrants and post-enrollment to trigger automatic scoring.
+
+### Program Membership Scoring
+
+Extends `spp.program.membership` with:
+
+| Field | Description |
+| --- | --- |
+| Enrollment Score | Score at the time of enrollment |
+| Enrollment Classification | Classification at the time of enrollment |
+| Latest Score | Computed field showing the most recent score |
+| Latest Classification | Computed field showing the most recent classification |
+
+### Scoring Model to Program Link
+
+Extends `spp.scoring.model` with a many-to-many relationship to programs, allowing users to see which programs use each scoring model.
+
+## Integration
+
+- **spp_scoring:** Uses the scoring engine to calculate and retrieve scores. Reuses existing scores when they are within the configured maximum age.
+- **spp_programs:** Extends program enrollment with pre/post hooks for eligibility checking and automatic score calculation. This module auto-installs when both `spp_scoring` and `spp_programs` are present.

--- a/docs/reference/modules/spp_security.md
+++ b/docs/reference/modules/spp_security.md
@@ -22,9 +22,9 @@ This module is designed to:
 
 ## Module Dependencies
 
-| Dependency | Purpose                                         |
-| ---------- | ----------------------------------------------- |
-| `base`     | Odoo core framework and security infrastructure |
+| Dependency | Purpose |
+| --- | --- |
+| `base` | Odoo core framework |
 
 ## Key Features
 
@@ -105,13 +105,3 @@ The security groups integrate with `spp_user_roles` for:
 - Role-based group assignment
 - Area-based access restrictions
 - Automated permission management
-
-## Technical Details
-
-| Property       | Value                      |
-| -------------- | -------------------------- |
-| Technical Name | `spp_security`             |
-| Category       | OpenSPP/Core               |
-| Version        | 19.0.1.0.0                 |
-| License        | LGPL-3                     |
-| Application    | No (infrastructure module) |

--- a/docs/reference/modules/spp_service_points.md
+++ b/docs/reference/modules/spp_service_points.md
@@ -22,13 +22,13 @@ This module is designed to:
 
 ## Module Dependencies
 
-| Dependency           | Description                                |
-| -------------------- | ------------------------------------------ |
-| **spp_registry**     | OpenSPP registry for registrant management |
-| **phone_validation** | Phone number formatting and validation     |
-| **spp_area**         | Geographical area hierarchy                |
-| **spp_security**     | OpenSPP security framework                 |
-| **spp_vocabulary**   | Controlled vocabulary management           |
+| Dependency | Purpose |
+| --- | --- |
+| `spp_registry` | Consolidated registry management for individuals, groups,... |
+| `phone_validation` | Phone number validation and formatting |
+| `spp_area` | Establishes direct associations between OpenSPP registran... |
+| `spp_security` | Central security definitions for OpenSPP modules |
+| `spp_vocabulary` | OpenSPP: Vocabulary |
 
 ## Key Features
 
@@ -147,13 +147,3 @@ The module defines a dedicated security group for service point users:
 ### Record Rules
 
 Access rules ensure users can only view and manage service points within their authorized scope based on area assignments.
-
-## Technical Details
-
-### Application Module
-
-This module is marked as an Odoo application (`application: True`), meaning it appears in the Apps menu and can be installed independently.
-
-### Registrant Service Point Computation
-
-When a registrant's parent (group/household) changes, the system automatically recomputes their service point associations based on the new parent's linked service points.

--- a/docs/reference/modules/spp_session_tracking.md
+++ b/docs/reference/modules/spp_session_tracking.md
@@ -1,0 +1,80 @@
+---
+openspp:
+  doc_status: draft
+---
+
+# Session Tracking
+
+**Module:** `spp_session_tracking`
+
+## Overview
+
+Track attendance at required sessions and trainings for social protection programs
+
+## Purpose
+
+This module is designed to:
+
+- **Schedule and manage sessions:** Create training sessions, workshops, or meetings with defined types, facilitators, and participants.
+- **Track attendance:** Record which participants attended each session, including excused absences with reasons.
+- **Monitor compliance:** Calculate attendance rates against expected participants and minimum attendance thresholds.
+
+## Module Dependencies
+
+| Dependency | Purpose |
+| --- | --- |
+| `base` | Odoo core framework |
+| `mail` | Communication and activity tracking |
+| `spp_area` | Establishes direct associations between OpenSPP registran... |
+| `spp_security` | Central security definitions for OpenSPP modules |
+
+## Key Features
+
+### Session Types
+
+Define reusable session type configurations:
+
+| Field | Description |
+| --- | --- |
+| Name / Code | Identifier for the session type |
+| Frequency | Weekly, Bi-weekly, Monthly, Quarterly, or One-time |
+| Required Attendance % | Minimum attendance percentage for compliance (default: 80%) |
+| Duration (Hours) | Default session length |
+| Track Topics | Whether to track which topics are covered per session |
+| Topics | List of topics available for this session type |
+
+### Sessions
+
+Each session represents a scheduled event:
+
+| Field | Description |
+| --- | --- |
+| Session Type | Links to a session type configuration |
+| Date / Start Time / End Time | Scheduling with automatic duration calculation |
+| Facilitator / Co-Facilitators | Assigned users responsible for the session |
+| Location / Area | Physical location and linked geographic area |
+| Expected Participants | Registrants expected to attend |
+| Max Participants | Optional capacity limit |
+| Topics Covered | Topics addressed during the session (when topic tracking is enabled) |
+| State | Scheduled, In Progress, Completed, or Cancelled |
+
+Sessions follow a strict state workflow: Scheduled can transition to In Progress or Cancelled; In Progress can transition to Completed or Cancelled. Completed and Cancelled are terminal states.
+
+### Attendance Records
+
+Each attendance record links a participant to a session:
+
+| Field | Description |
+| --- | --- |
+| Participant | The registrant who was expected or attended |
+| Attended | Whether the participant was present |
+| Attendance Time | Timestamp of attendance |
+| Excused | Whether the absence was excused |
+| Excuse Reason | Reason for excused absence |
+
+A unique constraint ensures each participant has only one attendance record per session. Attendance count and rate are computed automatically based on attended records versus expected participants.
+
+## Integration
+
+- **spp_area:** Sessions can be linked to geographic areas for location-based reporting and analysis.
+- **mail:** Sessions inherit mail.thread for activity tracking and change logging.

--- a/docs/reference/modules/spp_simulation.md
+++ b/docs/reference/modules/spp_simulation.md
@@ -1,0 +1,118 @@
+---
+openspp:
+  doc_status: draft
+---
+
+# Targeting Simulation
+
+**Module:** `spp_simulation`
+
+## Overview
+
+Simulate targeting scenarios, analyze fairness and distribution, and compare different targeting strategies before committing to criteria.
+
+## Purpose
+
+This module is designed to:
+
+- **Simulate targeting scenarios:** Define "what if" targeting strategies using CEL expressions and evaluate their impact before committing to real program criteria.
+- **Analyze fairness and distribution:** Compute equity scores, Gini coefficients, geographic breakdowns, and demographic parity metrics for each simulation run.
+- **Compare targeting strategies:** Run side-by-side comparisons of different scenarios to identify the most effective and equitable approach.
+- **Measure targeting accuracy:** Calculate leakage and undercoverage rates against an ideal target population.
+
+## Module Dependencies
+
+| Dependency | Purpose |
+| --- | --- |
+| `base` | Odoo core framework |
+| `mail` | Communication and activity tracking |
+| `spp_programs` | Manage cash and in-kind entitlements, integrate with inve... |
+| `spp_cel_domain` | Write simple CEL-like expressions to filter records (Open... |
+| `spp_cel_widget` | Reusable CEL expression editor with syntax highlighting a... |
+| `spp_security` | Central security definitions for OpenSPP modules |
+| `spp_analytics` | Query engine for indicators, simulations, and GIS analytics |
+| `spp_metric` | Unified metric foundation for indicators and simulations |
+
+## Key Features
+
+### Simulation Scenarios
+
+A scenario defines a targeting strategy to evaluate:
+
+| Field | Description |
+| --- | --- |
+| Target Type | Group (household) or Individual |
+| Targeting Expression | CEL expression defining who is eligible |
+| Budget Amount / Strategy | Budget limit and handling strategy (no constraint, cap at total, or proportional reduction) |
+| Entitlement Rules | Rules for calculating benefit amounts per beneficiary |
+| Ideal Population Expression | CEL expression defining who *should* receive benefits (for accuracy measurement) |
+| Custom Metrics | Additional metrics to compute during simulation |
+| Reference Program | Optional program for comparison context |
+
+Scenarios follow a Draft, Ready, Archived workflow. A targeting expression is required before marking a scenario as Ready. A live preview count shows how many registrants match the expression.
+
+### Entitlement Rules
+
+Each scenario can have multiple entitlement rules defining how benefit amounts are calculated:
+
+| Amount Mode | Description |
+| --- | --- |
+| Fixed Amount | Same amount per beneficiary |
+| Multiplier | Base amount multiplied by a registrant field value (e.g., household size), with optional maximum |
+| CEL Expression | Amount computed by a CEL expression |
+
+Rules can have optional condition expressions to apply only to a subset of targeted beneficiaries.
+
+### Simulation Runs
+
+Each run produces aggregated results that are preserved for audit compliance (runs cannot be deleted):
+
+| Metric | Description |
+| --- | --- |
+| Beneficiary Count | Number of registrants who would receive benefits |
+| Coverage Rate | Percentage of registry targeted |
+| Total Cost | Sum of all entitlement amounts |
+| Budget Utilization | Percentage of budget used |
+| Gini Coefficient | Measures benefit inequality (0 = equal, 1 = maximum inequality) |
+| Parity Score | 0-100 score measuring demographic coverage parity |
+| Leakage Rate | Percentage of recipients not in the ideal population |
+| Undercoverage Rate | Percentage of ideal population not targeted |
+
+Runs also store detailed JSON data for distribution statistics, fairness breakdowns, geographic analysis, targeting efficiency (confusion matrix), and custom metric results. Natural language HTML summaries are auto-generated for each section.
+
+### Scenario Templates
+
+Pre-built templates help non-technical users create scenarios quickly:
+
+| Field | Description |
+| --- | --- |
+| Category | Age-Based, Geographic, Vulnerability, Economic, or Categorical |
+| Targeting Expression | Pre-written CEL expression |
+| Default Amount / Mode | Suggested entitlement amount |
+| Ideal Population Expression | Pre-written accuracy benchmark |
+
+### Scenario Comparison
+
+Compare multiple simulation runs side by side:
+
+- Comparison of headline metrics (beneficiary count, cost, coverage, equity, leakage)
+- Parameter comparison showing differences in targeting expressions, budgets, and entitlement rules
+- Overlap analysis computing the Jaccard index between targeted populations
+- Staleness warnings when runs were executed far apart
+
+### Custom Metrics
+
+Define additional evaluation metrics for simulation scenarios:
+
+| Metric Type | Description |
+| --- | --- |
+| Aggregate | CEL expression aggregated via sum, avg, min, max, or count |
+| Coverage | CEL expression computing a coverage percentage |
+| Ratio | Numerator and denominator CEL expressions |
+
+## Integration
+
+- **spp_cel_domain / spp_cel_widget:** CEL expressions define targeting criteria, entitlement amounts, ideal population definitions, and custom metrics.
+- **spp_programs:** Scenarios can reference programs for comparison and can be converted into real programs.
+- **spp_analytics:** Provides the query engine for computing simulation analytics and geographic breakdowns.
+- **spp_metric:** Custom simulation metrics inherit from the unified metric base model.

--- a/docs/reference/modules/spp_source_tracking.md
+++ b/docs/reference/modules/spp_source_tracking.md
@@ -22,12 +22,12 @@ This module is designed to:
 
 ## Module Dependencies
 
-| Dependency       | Description                                |
-| ---------------- | ------------------------------------------ |
-| **base**         | Core Odoo framework                        |
-| **spp_security** | OpenSPP security framework                 |
-| **spp_registry** | OpenSPP registry for registrant management |
-| **spp_programs** | Program management                         |
+| Dependency | Purpose |
+| --- | --- |
+| `base` | Odoo core framework |
+| `spp_security` | Central security definitions for OpenSPP modules |
+| `spp_registry` | Consolidated registry management for individuals, groups,... |
+| `spp_programs` | Manage cash and in-kind entitlements, integrate with inve... |
 
 ## Key Features
 
@@ -171,27 +171,3 @@ Source tracking supports:
 - Data lineage documentation
 - Collection method verification
 - System integration auditing
-
-## Technical Details
-
-### Protected Fields
-
-Original provenance fields are immutable after creation:
-
-- `source_system`
-- `source_reference`
-- `collection_method`
-- `collection_date`
-
-These cannot be modified by `write()` operations.
-
-### Update Tracking
-
-Update provenance is automatically set on every write (unless `skip_source_tracking` context is set).
-
-### Migration Support
-
-The module includes post-migration scripts to:
-
-- Backfill source tracking on existing records
-- Handle schema changes during upgrades

--- a/docs/reference/modules/spp_starter_farmer_registry.md
+++ b/docs/reference/modules/spp_starter_farmer_registry.md
@@ -1,0 +1,60 @@
+---
+openspp:
+  doc_status: draft
+---
+
+# Starter: Farmer Registry
+
+**Module:** `spp_starter_farmer_registry`
+
+## Overview
+
+Complete Farmer Registry bundle with API, DCI, and Program support
+
+## Purpose
+
+This module is designed to:
+
+- **Provide a one-click farmer registry deployment:** Bundle all modules needed for a complete farmer registry into a single installable package, including social registry foundations, farmer-specific fields, land management, GIS, and program support.
+- **Set deployment-specific defaults:** Configure system parameters such as the smallholder farm size threshold (default: 5.0 hectares, adjustable per region following FAO recommendations).
+
+## Module Dependencies
+
+| Dependency | Purpose |
+| --- | --- |
+| `spp_starter_social_registry` | Complete Social Registry bundle with API, DCI, and Change... |
+| `spp_farmer_registry` | Farmer Registry with vocabulary-based fields, CEL variabl... |
+| `spp_farmer_registry_vocabularies` | FAO-aligned vocabularies for farmer registry (crops, live... |
+| `spp_land_record` | The OpenSPP Land Record module digitizes and centralizes ... |
+| `spp_irrigation` | Manages detailed irrigation assets by type, capacity, and... |
+| `spp_gis` | GIS core plus area geo fields and importer extensions (po... |
+| `spp_programs` | Manage cash and in-kind entitlements, integrate with inve... |
+
+## Key Features
+
+### Bundled Modules
+
+This is a meta-module that installs the following functional areas in a single step:
+
+| Area | Modules Included |
+| --- | --- |
+| Social Registry Foundation | `spp_starter_social_registry` (includes registry, security, area, vocabulary, API, DCI) |
+| Farmer Registry | `spp_farmer_registry`, `spp_farmer_registry_vocabularies` |
+| Land & GIS | `spp_land_record`, `spp_irrigation`, `spp_gis` |
+| Programs | `spp_programs` for subsidies and grants |
+
+### Configuration Parameters
+
+Sets the following system parameter on installation:
+
+| Parameter | Default | Description |
+| --- | --- | --- |
+| `spp.farmer.smallholder_threshold` | 5.0 | Maximum farm size (hectares) to qualify as a smallholder. Varies by region (Sub-Saharan Africa: 2 ha, South Asia: 2 ha, Southeast Asia: 3 ha, Latin America: 5-10 ha). |
+
+## Integration
+
+- **spp_starter_social_registry:** Inherits the complete social registry foundation, ensuring all prerequisite modules (registry, security, area, vocabulary, API, DCI, change requests) are installed.
+- **spp_farmer_registry:** Provides farmer-specific fields and CEL variables on the registry.
+- **spp_land_record / spp_irrigation:** Adds land parcel and irrigation asset management for agricultural contexts.
+- **spp_gis:** Enables geographic mapping and spatial analysis for farmer locations and land parcels.
+- **spp_programs:** Provides program management for agricultural subsidies, grants, and entitlements.

--- a/docs/reference/modules/spp_starter_social_registry.md
+++ b/docs/reference/modules/spp_starter_social_registry.md
@@ -23,26 +23,26 @@ This module is designed to:
 
 ## Module Dependencies
 
-| Category              | Modules                                                                    | Description                                               |
-| --------------------- | -------------------------------------------------------------------------- | --------------------------------------------------------- |
-| **Core Registry**     | spp_registry, spp_registry_search                                          | Individual and group management with search-first privacy |
-| **Security**          | spp_security                                                               | Role-based access control                                 |
-| **Geographic**        | spp_area                                                                   | Administrative boundary management                        |
-| **Vocabulary**        | spp_vocabulary                                                             | Standardized code lists                                   |
-| **Data Management**   | spp_consent, spp_source_tracking                                           | Consent management and data provenance                    |
-| **Async Processing**  | queue_job                                                                  | Background job processing                                 |
-| **Change Requests**   | spp_change_request_v2, spp_cr_types_base                                   | Data change workflows                                     |
-| **Expression Engine** | spp_cel_domain                                                             | CEL-based expressions                                     |
-| **No-Code UI**        | spp_studio                                                                 | Visual configuration tools                                |
-| **API**               | spp_api_v2, spp_api_v2_data                                                | REST API with consent-based access                        |
-| **DCI Integration**   | spp_dci_client, spp_dci_client_crvs, spp_dci_client_ibr, spp_dci_client_dr | External registry connections                             |
-
-### Auto-Installing Modules
-
-These modules install automatically when dependencies are met:
-
-- **spp_api_v2_vocabulary:** API endpoints for vocabularies (with spp_api_v2 + spp_vocabulary)
-- **spp_api_v2_change_request:** API endpoints for change requests (with spp_api_v2 + spp_change_request_v2)
+| Dependency | Purpose |
+| --- | --- |
+| `spp_registry` | Consolidated registry management for individuals, groups,... |
+| `spp_registry_search` | Search-first registry interface for privacy protection |
+| `spp_security` | Central security definitions for OpenSPP modules |
+| `spp_area` | Establishes direct associations between OpenSPP registran... |
+| `spp_vocabulary` | OpenSPP: Vocabulary |
+| `spp_consent` | DPV-aligned consent management for social protection prog... |
+| `spp_source_tracking` | Track data provenance and source information for registrants |
+| `job_worker` | Background job worker |
+| `spp_change_request_v2` | Configuration-driven change request system with UX improv... |
+| `spp_cr_types_base` | Basic change request types with field mapping strategy |
+| `spp_cel_domain` | Write simple CEL-like expressions to filter records (Open... |
+| `spp_studio` | No-code customization interface for OpenSPP |
+| `spp_api_v2` | OpenSPP API V2 - Standards-aligned, consent-respecting AP... |
+| `spp_api_v2_data` | REST API endpoints for Variable Data push/pull. |
+| `spp_dci_client` | Base DCI client infrastructure with OAuth2 and data sourc... |
+| `spp_dci_client_crvs` | Connect to CRVS registries via DCI API |
+| `spp_dci_client_ibr` | Connect to IBR for duplication checks via DCI API |
+| `spp_dci_client_dr` | Connect to Disability Registry via DCI API |
 
 ## Key Features
 

--- a/docs/reference/modules/spp_starter_sp_mis.md
+++ b/docs/reference/modules/spp_starter_sp_mis.md
@@ -22,23 +22,12 @@ This module is designed to:
 
 ## Module Dependencies
 
-| Dependency                      | Description                                        |
-| ------------------------------- | -------------------------------------------------- |
-| **spp_starter_social_registry** | Complete Social Registry foundation                |
-| **spp_programs**                | Program management with eligibility and enrollment |
-| **spp_approval**                | Multi-level approval workflows                     |
-| **spp_event_data**              | Audit trail for program activities                 |
-
-### Included from Social Registry
-
-Everything in `spp_starter_social_registry`:
-
-- Registry management for individuals and groups
-- Change request system for data maintenance
-- API V2 with consent-based access
-- DCI integration for external registries
-- Logic Studio for no-code expressions
-- Standardized vocabularies
+| Dependency | Purpose |
+| --- | --- |
+| `spp_starter_social_registry` | Complete Social Registry bundle with API, DCI, and Change... |
+| `spp_programs` | Manage cash and in-kind entitlements, integrate with inve... |
+| `spp_approval` | Standardized approval workflows with multi-tier sequencin... |
+| `spp_event_data` | Records and tracks events related to individual and group... |
 
 ## Key Features
 

--- a/docs/reference/modules/spp_storage_backend.md
+++ b/docs/reference/modules/spp_storage_backend.md
@@ -1,0 +1,66 @@
+---
+openspp:
+  doc_status: draft
+---
+
+# Storage Backend
+
+**Module:** `spp_storage_backend`
+
+## Overview
+
+Pluggable storage backend configuration for OpenSPP file storage
+
+## Purpose
+
+This module is designed to:
+
+- **Configure pluggable file storage:** Define multiple storage backends (Odoo default, S3, Azure Blob, external filesystem) and switch between them without code changes.
+- **Store and retrieve files:** Provide a unified API for storing, retrieving, and deleting files across different storage providers.
+- **Generate temporary access URLs:** Create presigned/SAS URLs for secure, time-limited file access on S3 and Azure backends.
+
+## Module Dependencies
+
+| Dependency | Purpose |
+| --- | --- |
+| `base` | Odoo core framework |
+| `spp_security` | Central security definitions for OpenSPP modules |
+
+## Key Features
+
+### Supported Backend Types
+
+| Backend Type | Description | Required Configuration |
+| --- | --- | --- |
+| Odoo Default | Standard Odoo filestore/database storage | None |
+| Amazon S3 / S3-Compatible | S3 or MinIO object storage | Bucket, Access Key, Secret Key, Region, optional Endpoint URL |
+| Azure Blob Storage | Microsoft Azure Blob containers | Connection String, Container Name |
+| External Filesystem | File storage on a mounted directory | Absolute base path |
+
+### Storage Operations
+
+Each backend provides a consistent interface:
+
+| Operation | Description |
+| --- | --- |
+| `store(binary_data, path)` | Store binary data and return a storage reference |
+| `retrieve(reference)` | Retrieve binary data by its storage reference |
+| `delete(reference)` | Delete a file by its storage reference |
+| `get_public_url(reference, expires_in)` | Generate a time-limited public URL (S3 and Azure only) |
+| `test_connection()` | Verify the backend is accessible and properly configured |
+
+### Default Backend
+
+One backend can be designated as the default. The `get_default_backend()` method returns the default active backend, falling back to the first active Odoo backend, then any active backend.
+
+### Security
+
+- Only one backend can be marked as default (enforced by database constraint).
+- S3, Azure, and filesystem backends validate required configuration fields before saving.
+- Filesystem backend validates that the base path is absolute and prevents path traversal attacks.
+- Connection testing is available via a UI button to verify backend accessibility before use.
+
+## Integration
+
+- **spp_security:** Uses OpenSPP security groups for access control to storage backend configuration.
+- Other OpenSPP modules can use `spp.storage.backend` to store and retrieve files (e.g., attachments, exports, scan results) through the unified storage API.

--- a/docs/reference/modules/spp_studio.md
+++ b/docs/reference/modules/spp_studio.md
@@ -24,19 +24,22 @@ This module is designed to:
 
 ## Module Dependencies
 
-| Module               | Description                                           |
-| -------------------- | ----------------------------------------------------- |
-| **spp_registry**     | Core registry for individuals and groups              |
-| **spp_programs**     | Program management functionality                      |
-| **spp_custom_field** | Foundation for custom field definitions               |
-| **spp_cel_domain**   | Unified variable system and CEL expression evaluation |
-| **spp_cel_widget**   | CEL expression editor widget                          |
-| **spp_vocabulary**   | Controlled vocabularies for tags and categories       |
-| **spp_approval**     | Approval workflow integration                         |
-| **spp_versioning**   | Version history with scheduled activation             |
-| **spp_audit**        | Audit trail logging                                   |
-| **spp_security**     | Security group management                             |
-| **spp_user_roles**   | User role definitions                                 |
+| Dependency | Purpose |
+| --- | --- |
+| `base` | Odoo core framework |
+| `mail` | Communication and activity tracking |
+| `spp_audit` | Comprehensively tracks all data modifications and user ac... |
+| `spp_security` | Central security definitions for OpenSPP modules |
+| `spp_registry` | Consolidated registry management for individuals, groups,... |
+| `spp_base_common` | The OpenSPP base module that provides the main menu, gene... |
+| `spp_programs` | Manage cash and in-kind entitlements, integrate with inve... |
+| `spp_user_roles` | The OpenSPP User Roles module defines and manages distinc... |
+| `spp_custom_field` | The module enables administrators to define and add custo... |
+| `spp_cel_domain` | Write simple CEL-like expressions to filter records (Open... |
+| `spp_cel_widget` | Reusable CEL expression editor with syntax highlighting a... |
+| `spp_vocabulary` | OpenSPP: Vocabulary |
+| `spp_approval` | Standardized approval workflows with multi-tier sequencin... |
+| `spp_versioning` | Artifact versioning with scheduled activation |
 
 ## Key Features
 
@@ -140,3 +143,12 @@ Logic can be used in event-triggered calculations:
 - {doc}`spp_studio_events` - No-code event type designer
 - {doc}`spp_studio_change_requests` - No-code change request type builder
 - {doc}`spp_custom_field` - Foundation for custom fields
+
+```{toctree}
+:maxdepth: 1
+:hidden:
+
+spp_studio_api_v2
+spp_studio_change_requests
+spp_studio_events
+```

--- a/docs/reference/modules/spp_studio_api_v2.md
+++ b/docs/reference/modules/spp_studio_api_v2.md
@@ -1,0 +1,95 @@
+---
+openspp:
+  doc_status: draft
+---
+
+# API v2 Integration
+
+**Module:** `spp_studio_api_v2`
+
+## Overview
+
+Bridge Studio custom fields and variables with API v2
+
+## Purpose
+
+This module is designed to:
+
+- **Expose Studio custom fields via API v2:** Automatically register Studio-defined fields in API v2 extensions so they appear in Individual and Group API responses and accept updates.
+- **Provide Studio field discovery endpoints:** Allow API clients to list custom fields, retrieve their JSON Schema validation rules, and browse available CEL variables.
+- **Support extension writes:** Parse incoming API extension data (CodeableConcept, date, numeric types) and convert them to Odoo field values for create/update operations.
+- **Serve computed variable values:** Return cached CEL variable values for Individual and Group registrants via dedicated API endpoints.
+
+## Module Dependencies
+
+| Dependency | Purpose |
+| --- | --- |
+| `spp_api_v2` | OpenSPP API V2 - Standards-aligned, consent-respecting AP... |
+| `spp_studio` | No-code customization interface for OpenSPP |
+| `spp_cel_domain` | Write simple CEL-like expressions to filter records (Open... |
+
+## Key Features
+
+### Auto-Registration of Studio Fields
+
+When a Studio field is activated, it is automatically added to the appropriate API v2 extension (Individual or Group). When deactivated, it is removed. An `api_exposed` flag on each Studio field controls whether it appears in API responses.
+
+### Studio API Endpoints
+
+All endpoints require the `studio:read` API scope.
+
+| Endpoint | Method | Description |
+| --- | --- | --- |
+| `/Studio/fields` | GET | List all active Studio custom fields with filtering by target type and pagination |
+| `/Studio/fields/{technical_name}/schema` | GET | Get JSON Schema for a specific field (type, constraints, enum values, visibility rules) |
+| `/Studio/variables` | GET | List active CEL variables with filtering by context, source type, and category |
+| `/Studio/variables/{resource_type}/{identifier}` | GET | Get cached variable values for a specific Individual or Group |
+
+### Field Schema
+
+The schema endpoint returns JSON Schema-compatible metadata for each Studio field:
+
+| Schema Property | Description |
+| --- | --- |
+| type | JSON Schema type (string, number, boolean, object, array) |
+| format | date, date-time, or reference for link fields |
+| enum / enumDisplay | Allowed values and display labels for selection fields |
+| minimum / maximum | Numeric constraints |
+| maxLength | String length limits (255 for text, 65535 for long text) |
+| linkModel / linkDomain | Target model and domain filter for link fields |
+| visibilityField / Operator / Value | Conditional visibility rules |
+
+### Extension Write Service
+
+Handles reverse mapping from API format to Odoo field values:
+
+| API Format | Odoo Conversion |
+| --- | --- |
+| camelCase field names | snake_case with `x_` prefix |
+| CodeableConcept (`{coding: [{system, code}]}`) | Many2one vocabulary code lookup |
+| Arrays of CodeableConcept | Many2many with `Command.set()` |
+| ISO date strings | Passed through to Odoo date/datetime fields |
+| String booleans (`"true"`, `"1"`) | Python bool |
+| `namespace\|value` identifiers | Vocabulary code lookup by namespace_uri and code |
+
+A model allowlist (`SAFE_LOOKUP_MODELS`) restricts display name lookups to safe reference models like `spp.vocabulary.code`, `res.country`, and `res.partner.category`. Sensitive models are explicitly blocked.
+
+### Variable Value Service
+
+Retrieves cached variable values from `spp.data.value` for API responses:
+
+- Single subject queries by partner ID
+- Bulk queries for multiple partners (up to 1,000 per batch)
+- Period-based historical queries
+- Optional stale value filtering
+- On-demand computation for field-type variables on safe source models
+
+### API Client Scope
+
+Extends the API client scope model with a `studio` resource type, allowing fine-grained access control for Studio API endpoints.
+
+## Integration
+
+- **spp_api_v2:** Adds the Studio router to the API v2 FastAPI endpoint. Patches `IndividualService` and `GroupService` to handle extension data writes and include computed variable values in responses.
+- **spp_studio:** Extends Studio field lifecycle hooks (`_post_activate`, `_post_deactivate`) to automatically register/unregister fields in API extensions.
+- **spp_cel_domain:** CEL variables and their cached values are exposed through the variables API endpoints for external system consumption.

--- a/docs/reference/modules/spp_studio_change_requests.md
+++ b/docs/reference/modules/spp_studio_change_requests.md
@@ -3,7 +3,7 @@ openspp:
   doc_status: draft
 ---
 
-# Studio - Change Requests
+# Change Requests
 
 **Module:** `spp_studio_change_requests`
 
@@ -23,12 +23,12 @@ This module is designed to:
 
 ## Module Dependencies
 
-| Module                    | Description                                   |
-| ------------------------- | --------------------------------------------- |
-| **spp_studio**            | Core Studio interface and mixin functionality |
-| **spp_change_request_v2** | Change request infrastructure and processing  |
-| **spp_registry**          | Registry models for field mapping             |
-| **spp_audit**             | Audit trail logging                           |
+| Dependency | Purpose |
+| --- | --- |
+| `spp_studio` | No-code customization interface for OpenSPP |
+| `spp_change_request_v2` | Configuration-driven change request system with UX improv... |
+| `spp_registry` | Consolidated registry management for individuals, groups,... |
+| `spp_audit` | Comprehensively tracks all data modifications and user ac... |
 
 ## Key Features
 

--- a/docs/reference/modules/spp_studio_events.md
+++ b/docs/reference/modules/spp_studio_events.md
@@ -3,7 +3,7 @@ openspp:
   doc_status: draft
 ---
 
-# Studio - Events
+# Events
 
 **Module:** `spp_studio_events`
 
@@ -24,10 +24,10 @@ This module is designed to:
 
 ## Module Dependencies
 
-| Module             | Description                                   |
-| ------------------ | --------------------------------------------- |
-| **spp_studio**     | Core Studio interface and mixin functionality |
-| **spp_event_data** | Event data infrastructure and storage         |
+| Dependency | Purpose |
+| --- | --- |
+| `spp_studio` | No-code customization interface for OpenSPP |
+| `spp_event_data` | Records and tracks events related to individual and group... |
 
 ## Key Features
 

--- a/docs/reference/modules/spp_user_roles.md
+++ b/docs/reference/modules/spp_user_roles.md
@@ -22,13 +22,13 @@ This module is designed to:
 
 ## Module Dependencies
 
-| Dependency         | Description                                |
-| ------------------ | ------------------------------------------ |
-| **base**           | Core Odoo framework                        |
-| **mail**           | Messaging and notification support         |
-| **spp_registry**   | OpenSPP registry for registrant management |
-| **base_user_role** | Base user role management from OCA         |
-| **spp_security**   | OpenSPP security framework                 |
+| Dependency | Purpose |
+| --- | --- |
+| `base` | Odoo core framework |
+| `mail` | Communication and activity tracking |
+| `spp_registry` | Consolidated registry management for individuals, groups,... |
+| `base_user_role` | User role management (OCA) |
+| `spp_security` | Central security definitions for OpenSPP modules |
 
 ## Key Features
 
@@ -98,13 +98,3 @@ Roles are assigned through role lines on the user record:
 | Date From  | Optional start date for the assignment |
 | Date To    | Optional end date for the assignment   |
 | Is Enabled | Toggle to enable/disable the role line |
-
-## Technical Details
-
-### Auto-Install Behavior
-
-This module auto-installs when both `spp_registry` and `base_user_role` are installed, ensuring role management is available whenever the registry is in use.
-
-### Scheduled Actions
-
-The module includes scheduled actions (cron jobs) for maintaining role synchronization across users.

--- a/docs/reference/modules/spp_versioning.md
+++ b/docs/reference/modules/spp_versioning.md
@@ -22,10 +22,10 @@ This module is designed to:
 
 ## Module Dependencies
 
-| Dependency       | Description                            |
-| ---------------- | -------------------------------------- |
-| **spp_security** | OpenSPP security groups and privileges |
-| **mail**         | Activity tracking and notifications    |
+| Dependency | Purpose |
+| --- | --- |
+| `spp_security` | Central security definitions for OpenSPP modules |
+| `mail` | Communication and activity tracking |
 
 ## Key Features
 

--- a/docs/reference/modules/spp_vocabulary.md
+++ b/docs/reference/modules/spp_vocabulary.md
@@ -22,11 +22,11 @@ This module is designed to:
 
 ## Module Dependencies
 
-| Dependency       | Description                            |
-| ---------------- | -------------------------------------- |
-| **base**         | Odoo core functionality                |
-| **mail**         | Messaging and activity tracking        |
-| **spp_security** | OpenSPP security groups and privileges |
+| Dependency | Purpose |
+| --- | --- |
+| `base` | Odoo core framework |
+| `mail` | Communication and activity tracking |
+| `spp_security` | Central security definitions for OpenSPP modules |
 
 ## Key Features
 

--- a/docs/reference/modules/theme_openspp_muk.md
+++ b/docs/reference/modules/theme_openspp_muk.md
@@ -22,11 +22,11 @@ This module is designed to:
 
 ## Module Dependencies
 
-| Dependency        | Description                                    |
-| ----------------- | ---------------------------------------------- |
-| **base**          | Odoo core functionality                        |
-| **web**           | Odoo web client assets                         |
-| **muk_web_theme** | MuK Hacker theme as the base styling framework |
+| Dependency | Purpose |
+| --- | --- |
+| `base` | Odoo core framework |
+| `web` | Web interface components |
+| `muk_web_theme` | MuK web theme framework |
 
 ## Key Features
 


### PR DESCRIPTION
## Why is this change needed?
Module reference docs were incomplete — only 51 of 110 modules had docs, many had outdated dependency tables, and the sidebar navigation was flat.

## How was the change implemented?
- Added 59 missing module reference docs with content generated from reading source code
- Synced dependency tables in all 51 existing docs with current `__manifest__.py`
- Removed Technical Details sections (version/license metadata goes stale quickly)
- Removed redundant "OpenSPP" prefix from all module titles
- Added nested sidebar navigation for 13 module groups (API V2, Case, CEL, DCI, DRIMS, Farmer Registry, GIS, GRM, Hazard, HXL, Scoring, Studio, Change Request)
- Updated index.md with all 110 modules organized into categories

## New unit tests

## Unit tests executed by the author

## How to test manually
- Build docs with `make html`
- Check module reference index at `/reference/modules/`
- Verify nested sidebar navigation works (e.g., API V2 > Cycles, GIS > Reports)
- Spot-check a few module pages for accuracy

## Related links