### PR TITLE
fix(config_guide): correct CEL and variables docs against codebase

### DIFF
--- a/docs/config_guide/cel/cookbook.md
+++ b/docs/config_guide/cel/cookbook.md
@@ -220,6 +220,10 @@ has_event("health_check", within_months=6)
 
 ## Eligibility rules
 
+```{note}
+The examples below use variables like `household_income`, `poverty_line`, `children_under_5_count`, etc. These must be defined and activated in **Studio → Variables** before they can be used in expressions. See {doc}`variables` for how to create them.
+```
+
 ### Income-based
 
 Household income under threshold:
@@ -346,9 +350,9 @@ has(r.birthdate) and between(age_years(r.birthdate), 0, 120)
 
 ### Format check
 
-Phone number prefix:
+Phone number prefix (using regex):
 ```cel
-startswith(r.phone, "+63")
+matches(r.phone, "^\\+63")
 ```
 
 ID format with regex:
@@ -391,7 +395,7 @@ r.area_id.name == "NCR" ? "ncr_team" : "regional_team"
 2. **Verify context**: Individual vs group expressions need different symbols
 3. **Test incrementally**: Start simple, add complexity
 4. **Use variables**: Extract repeated logic into variables
-5. **Add tests**: Create test cases in Studio before publishing
+5. **Add tests**: Create test cases in Studio before activating
 
 ## Are you stuck?
 

--- a/docs/config_guide/cel/quick_start.md
+++ b/docs/config_guide/cel/quick_start.md
@@ -86,7 +86,7 @@ There are two ways to access Variables:
 
 **Option B - From Menu:**
 1. Click **Studio** in the main menu
-2. Click **Rules** in the top menu bar
+2. Click **Logic Design** in the top menu bar
 3. Click **Variables**
 
 ### Step 2: Create a new variable
@@ -154,7 +154,7 @@ Now you can use `children_under_5_count` in any expression that applies to group
 
 **Option B - From Menu:**
 1. Click **Studio** in the main menu
-2. Click **Rules** in the top menu bar
+2. Click **Logic Design** in the top menu bar
 3. Click **Expressions**
 
 ### Step 2: Create a new expression
@@ -217,14 +217,13 @@ The editor provides:
 Add test cases and click **Run All Tests** to verify your expression.
 ```
 
-### Step 6: Save and publish
+### Step 6: Save and activate
 
 1. Click **Save** to create the expression in Draft state
-2. Click **Submit for Approval** to request publication
-3. Once approved, the expression will be **Published** and available for use
+2. Click **Activate** to make it available for use
 
 ```{note}
-Expressions follow a workflow: Draft → Pending Approval → Published → Archived. Only users with approval permissions can publish expressions.
+Expressions follow the same workflow as variables: Draft → Active → Inactive.
 ```
 
 ## How to know what data is available
@@ -295,9 +294,8 @@ The editor shows real-time validation:
 - Check that referenced variables are Active
 - Verify the context matches (individual vs group profiles have different symbols)
 
-**Can't activate a variable or publish an expression?**
-- Variables: You need **Studio Manager** permission to activate
-- Expressions: You need approval permissions to publish (expressions go through an approval workflow)
+**Can't activate a variable or expression?**
+- You need **Studio Manager** permission to activate variables and expressions
 - Check that all required fields are filled
 - For aggregates, verify the filter expression is valid
 

--- a/docs/config_guide/cel/syntax.md
+++ b/docs/config_guide/cel/syntax.md
@@ -106,10 +106,12 @@ has(r.birthdate) and age_years(r.birthdate) >= 18
 
 | Function | Example | Description |
 |----------|---------|-------------|
-| `startswith(field, prefix)` | `startswith(r.id, "PH-")` | Check prefix |
-| `contains(field, text)` | `contains(r.name, "Jr")` | Check substring |
 | `matches(field, pattern)` | `matches(r.id, "^PH-[0-9]+$")` | Regex match |
 | `size(s)` | `size(r.name)` | String/collection length |
+
+```{note}
+Use `matches()` with regex patterns for prefix or substring checks. For example, `matches(r.id, "^PH-")` checks for a prefix, and `matches(r.name, "Jr")` checks for a substring.
+```
 
 ### Utility functions
 
@@ -149,9 +151,9 @@ enrollments.exists(e, e.state == "enrolled")
 The loop variable (`m`, `e`, etc.) represents each item in the collection.
 
 ```{note}
-Newer syntax may omit the explicit loop variable:
-`members.count(age_years(m.birthdate) < 5)`
-Both forms are supported.
+The loop variable declaration can be omitted from the first argument position:
+`members.count(age_years(m.birthdate) < 5)` is equivalent to `members.count(m, age_years(m.birthdate) < 5)`.
+In both forms, `m` is still used inside the predicate to reference each member.
 ```
 
 ## Profiles and symbols
@@ -165,13 +167,13 @@ Profiles define what data is available in a given context:
 
 ### Default profiles
 
-| Profile | Root Model | Available Relations |
-|---------|-----------|---------------------|
-| `registry_individuals` | `res.partner` (individual) | `groups`, `enrollments`, `entitlements`, `events` |
-| `registry_groups` | `res.partner` (group) | `members`, `enrollments`, `entitlements`, `events` |
-| `program_memberships` | `spp.program.membership` | - |
-| `entitlements` | `spp.entitlement` | - |
-| `grm_tickets` | `spp.grm.ticket` | - |
+| Profile | Root Record | Available Relations |
+|---------|------------|---------------------|
+| `registry_individuals` | Individual registrant | `groups`, `enrollments`, `entitlements`, `events` |
+| `registry_groups` | Group/household | `members`, `enrollments`, `entitlements`, `events` |
+| `program_memberships` | Program membership | - |
+| `entitlements` | Entitlement record | - |
+| `grm_tickets` | GRM ticket | - |
 
 ### Root record symbol
 

--- a/docs/config_guide/cel/troubleshooting.md
+++ b/docs/config_guide/cel/troubleshooting.md
@@ -195,7 +195,6 @@ The expression is syntactically correct but finds no matches.
 
 - Expression takes long to validate
 - Eligibility check times out
-- "Python fallback" warnings
 
 ### Causes and solutions
 
@@ -217,13 +216,10 @@ For expensive computations:
 
 ### Simplify event queries
 
-Instead of complex `where` predicates:
+Use specific event type codes rather than filtering broadly:
 
 ```cel
-# May fall back to Python
-events_count("visit", where="data->>'type' == 'home'", within_days=90)
-
-# Prefer simpler form
+# Prefer specific event types
 events_count("home_visit", within_days=90)
 ```
 

--- a/docs/config_guide/cel/variables.md
+++ b/docs/config_guide/cel/variables.md
@@ -8,7 +8,7 @@ openspp:
 
 This guide is for **implementers** configuring CEL variables in OpenSPP.
 
-Variables (`spp.cel.variable`) define named data points that can be reused across expressions and features. Define them once, use them everywhere.
+Variables define named data points that can be reused across expressions and features. Define them once, use them everywhere.
 
 ## Why use variables?
 
@@ -64,7 +64,7 @@ Calculated from a CEL expression.
 
 ### Aggregate
 
-Computes over related records (members, enrollments, entitlements, events).
+Computes over related records (members, enrollments, entitlements).
 
 | Field | Value |
 |-------|-------|
@@ -101,7 +101,10 @@ Aggregates are the most powerful variable type. They compute values across colle
 | Members | Household members | `m` |
 | Enrollments | Program memberships | `e` |
 | Entitlements | Entitlement records | `ent` |
-| Events | Event data records | `evt` |
+
+```{note}
+Event data is not an aggregate target. To work with events, use the dedicated event functions (`has_event`, `events_count`, etc.) described below.
+```
 
 ### Aggregate types
 

--- a/docs/config_guide/variables/creating_variables.md
+++ b/docs/config_guide/variables/creating_variables.md
@@ -199,7 +199,7 @@ Go to **Studio → Expressions** and verify the variable appears in autocomplete
 
 ## Creating Aggregate Variables
 
-Aggregates compute values over household members, enrollments, or events.
+Aggregates compute values over household members, enrollments, or entitlements.
 
 ### Example: Count Children Under 5
 
@@ -253,9 +253,9 @@ Use `m.` prefix to reference member fields:
 | `age_years(m.birthdate) < 18` | Member is under 18 |
 | `m.is_head_of_household == true` | Member is HOH |
 
-## Creating Event Aggregates
+## Creating Event-Based Variables
 
-Aggregate over event data with time filtering.
+Event data is accessed through dedicated event functions, not the aggregate system. Use a **Computed (CEL)** variable with event functions.
 
 ### Example: Count Health Visits This Year
 
@@ -263,23 +263,14 @@ Aggregate over event data with time filtering.
 |-------|-------|
 | Name | `health_visits_this_year` |
 | Label | Health Visits This Year |
-| Source Type | Member Aggregate |
-| Aggregate Type | Count |
-| Aggregate Target | Events |
-| Event Type | Health Visit |
-| Time Range | This Year |
+| Source Type | Computed (CEL) |
+| CEL Expression | `events_count("health_visit", within_months=12)` |
 | Value Type | Number |
+| Applies To | Individual |
 
-### Event Time Range Options
-
-| Option | Description |
-|--------|-------------|
-| All Time | All events ever |
-| This Year | Current calendar year |
-| This Quarter | Current quarter |
-| This Month | Current month |
-| Within N Days | Last N days |
-| Within N Months | Last N months |
+```{note}
+Event functions require the `spp_cel_event` module. See the {doc}`/config_guide/cel/variables` guide for the full list of event functions and time range parameters (`within_days`, `within_months`, `period`).
+```
 
 ## Creating Program Constants
 

--- a/docs/config_guide/variables/index.md
+++ b/docs/config_guide/variables/index.md
@@ -4,7 +4,7 @@ openspp:
   products: [core]
 ---
 
-# Variables & Indicators
+# Variables
 
 This guide is for **implementers** configuring variables to define, cache, and reference data points in CEL expressions.
 

--- a/docs/config_guide/variables/using_variables.md
+++ b/docs/config_guide/variables/using_variables.md
@@ -58,9 +58,9 @@ Match variable types with appropriate operators:
 | Number | `>`, `<`, `>=`, `<=`, `==`, `!=`, `+`, `-`, `*`, `/` |
 | Money | Same as Number |
 | Yes/No | `==`, `!=`, `&&`, `\|\|`, `!` |
-| Text | `==`, `!=`, `contains()`, `startsWith()` |
-| Date | `==`, `!=`, `>`, `<`, `before()`, `after()` |
-| List | `in`, `size()`, `contains()` |
+| Text | `==`, `!=`, `matches()` |
+| Date | `==`, `!=`, `>`, `<`, `>=`, `<=` |
+| List | `size()` |
 
 ## Common Patterns
 
@@ -355,7 +355,7 @@ Break complex logic into multiple variables or eligibility rules.
 **Aggregate seems wrong?**
 
 - Verify filter expression
-- Check aggregate target (members vs events)
+- Check aggregate target (members, enrollments, or entitlements)
 - Test filter separately first
 
 ## Next Steps

--- a/docs/config_guide/variables/variable_types.md
+++ b/docs/config_guide/variables/variable_types.md
@@ -111,7 +111,7 @@ Calculate values using CEL expressions.
 
 ## Member Aggregate Variables
 
-Compute values over household members, enrollments, entitlements, or events.
+Compute values over household members, enrollments, or entitlements.
 
 ### When to Use
 
@@ -149,7 +149,10 @@ Compute values over household members, enrollments, entitlements, or events.
 | Household Members | Members of the household |
 | Program Enrollments | Program membership records |
 | Entitlements | Entitlement records |
-| Events | Event data records |
+
+```{note}
+Event data is not available as an aggregate target. To work with event data, use the dedicated event functions (`has_event`, `events_count`, `events_sum`, etc.) described in the {doc}`/config_guide/cel/variables` guide.
+```
 
 ### Example: Count Children
 
@@ -198,40 +201,19 @@ m.is_disabled == true             # Disabled members
 age_years(m.birthdate) < 18 && m.is_enrolled_in_school == true
 ```
 
-## Event Aggregate Variables
+## Working with Event Data
 
-Aggregate over event data with time filtering.
+Event data is accessed through dedicated event functions in CEL expressions, not through the aggregate variable system.
 
-### Configuration
-
-| Field | Value | Notes |
-|-------|-------|-------|
-| Source Type | Member Aggregate | |
-| Aggregate Target | Events | |
-| Event Type | (select event type) | Which event type |
-| Time Range | This Year | Temporal filter |
-| Event Field | `amount` | For sum/avg (JSON field in event) |
-
-### Time Range Options
-
-| Option | Description |
-|--------|-------------|
-| All Time | All events |
-| This Year | Current calendar year |
-| This Quarter | Current quarter |
-| This Month | Current month |
-| Within N Days | Last N days (specify N) |
-| Within N Months | Last N months (specify N) |
+To work with events, use a **Computed (CEL)** variable with event functions:
 
 ### Example: Health Visits This Year
 
 | Setting | Value |
 |---------|-------|
 | Name | `health_visits_year` |
-| Aggregate Type | Count |
-| Aggregate Target | Events |
-| Event Type | Health Visit |
-| Time Range | This Year |
+| Source Type | Computed (CEL) |
+| CEL Expression | `events_count("health_visit", within_months=12)` |
 | Value Type | Number |
 
 ### Example: Total Training Hours
@@ -239,12 +221,13 @@ Aggregate over event data with time filtering.
 | Setting | Value |
 |---------|-------|
 | Name | `training_hours` |
-| Aggregate Type | Sum |
-| Aggregate Target | Events |
-| Event Type | Training Session |
-| Time Range | All Time |
-| Event Field | `duration_hours` |
+| Source Type | Computed (CEL) |
+| CEL Expression | `events_sum("training_session", "duration_hours")` |
 | Value Type | Number |
+
+```{note}
+Event functions require the `spp_cel_event` module to be installed. See the {doc}`/config_guide/cel/variables` guide for the full list of event functions and parameters.
+```
 
 ## Constant/Parameter Variables
 
@@ -332,7 +315,7 @@ Fetch data from external providers.
 | External Provider | (select provider) | Pre-configured data provider |
 
 ```{note}
-External providers must be configured separately in **Settings → Data Providers**.
+External providers must be configured separately by your administrator. Ask them to set up the data provider connection before using this source type.
 ```
 
 ### Caching Recommendation


### PR DESCRIPTION
## Why is this change needed?

QA review found 14 inaccuracies in the CEL and variables documentation when verified against the OpenSPP2 codebase.

## How was the change implemented?

- Fixed expression states: Draft → Active → Inactive (was Draft → Pending Approval → Published → Archived)
- Fixed menu path: Studio → Logic Design (was Studio → Rules)
- Removed non-existent functions: startswith(), contains(), before(), after()
- Removed Events as aggregate target (only members, enrollments, entitlements exist)
- Rewrote event aggregate sections to use Computed (CEL) with event functions
- Removed undocumented `where` parameter and Python fallback references
- Clarified collection predicate syntax note
- Replaced raw Odoo model names in profiles table
- Renamed "Variables & Indicators" to "Variables"

## Related links

https://projects.acn.fr/projects/acn-eng/work_packages/823