### PR TITLE
docs(config_guide): cross-cutting QA — complete index and reduce jargon

### DIFF
--- a/docs/config_guide/cel/syntax.md
+++ b/docs/config_guide/cel/syntax.md
@@ -246,7 +246,7 @@ Used for record selection (eligibility, search):
 Used for value computation (amounts, routing):
 - Works with provided context dictionary
 - Supports arithmetic and comparisons
-- No ORM access
+- Cannot read records directly from the database (use compile-to-domain mode for that)
 
 | Feature | Compile-to-Domain | Runtime |
 |---------|-------------------|---------|

--- a/docs/config_guide/change_request_types/overview.md
+++ b/docs/config_guide/change_request_types/overview.md
@@ -22,7 +22,7 @@ Change request types define the different kinds of modifications that can be mad
 Change requests in OpenSPP V2 follow a configuration-driven architecture with three layers:
 
 1. **Request Type** - Defines what kind of change can be made (e.g., "Add Member", "Edit Individual")
-2. **Detail Model** - Stores the specific fields for this request type (real Odoo fields, not JSON)
+2. **Detail Model** - Stores the specific fields for this request type as structured, queryable fields (not packed into a single free-form blob)
 3. **Apply Strategy** - Controls how approved changes are written to the registrant record
 
 ```

--- a/docs/config_guide/consent/api_consent_filtering.md
+++ b/docs/config_guide/consent/api_consent_filtering.md
@@ -21,7 +21,7 @@ Partner API Request → Check consent_summary → Filter response → Return dat
 
 ## Consent summary cache
 
-Each registrant has a `consent_summary` JSON field that caches their active consents for fast API filtering. This enables O(1) consent checks instead of querying consent records on every request.
+Each registrant has a `consent_summary` field that caches their active consents for fast API filtering. The system reads this single cached value instead of looking up consent records one by one on every request.
 
 **Structure:**
 ```json

--- a/docs/config_guide/drims/index.md
+++ b/docs/config_guide/drims/index.md
@@ -113,6 +113,6 @@ Alert jobs run on schedule (low stock every 4 hours, SLA every 2 hours, expiry d
 Most DRIMS configuration can be done through the interface. You only need custom development for:
 
 - Custom alert types beyond low stock/SLA/expiry
-- Integration with external systems (3PL, OCHA HDX, etc.)
+- Integration with external systems (third-party logistics providers, humanitarian data exchanges, etc.)
 - Custom entitlement calculations for beneficiary-based distribution
-- Advanced reporting beyond 4W reports and dashboards
+- Advanced reporting beyond standard "Who, What, Where, When" (4W) reports and dashboards

--- a/docs/config_guide/index.md
+++ b/docs/config_guide/index.md
@@ -8,45 +8,77 @@ openspp:
 
 **For: implementers** (M&E teams, technical staff comfortable with Kobo/CommCare level configuration)
 
-This guide covers configuring OpenSPP without code - setting up eligibility rules, formulas, workflows, and system behavior through the OpenSPP Studio interface and configuration files.
+This guide covers configuring OpenSPP without code — setting up eligibility rules, formulas, workflows, and system behavior through the OpenSPP Studio interface and configuration screens.
 
 ## Overview
 
-The Configuration Guide is designed for implementers who need to customize OpenSPP for their specific program requirements. No programming knowledge is required - configuration uses visual tools and simple expression languages.
+The Configuration Guide is designed for implementers who need to customize OpenSPP for their specific program requirements. No programming knowledge is required — configuration uses visual tools and simple expression languages.
 
 ## Topics covered
 
-- **[OpenSPP Studio](studio/index.md)** - No-code configuration tool (NEW V2)
-- **[CEL Expressions](cel/index.md)** - Common Expression Language for rules and formulas
-- **[Eligibility rules](eligibility/index.md)** - Configuring who qualifies for programs
-- **[Entitlement formulas](entitlement_formulas/index.md)** - Calculating benefit amounts
-- **[Vocabulary system](vocabulary/index.md)** - Standardized codes and terminologies (NEW V2)
-- **[Variables and indicators](variables/index.md)** - Unified variable system (NEW V2)
-- **[Event data](event_data/index.md)** - Capturing external data from surveys and forms (V2 enhanced)
-- **[Change request types](change_request_types/index.md)** - Configuring change request workflows (NEW V2)
-- **[Consent configuration](consent/index.md)** - Managing data sharing consent (NEW V2)
-- **[Role configuration](role_configuration/index.md)** - Configuring users, roles, and role-based access (global and local roles)
-- **[Custom fields](custom_fields/index.md)** - Registrant field groups
-- **[Import matching](import_matching/index.md)** - Deduplication during import
-- **[Farmer registry](farmer_registry/index.md)** - Farm entity configuration
+- **[Alerts](alerts/index.md)** — Rule-based monitoring and notifications
+- **[Approval workflows](approval_workflows/index.md)** — Multi-tier approval routing for change requests and programs
+- **[Area management](area_management/index.md)** — Administrative hierarchy and geographic boundaries
+- **[Audit configuration](audit/index.md)** — Tracking and logging system changes
+- **[Banking](banking/index.md)** — Bank codes and payment account configuration
+- **[Case management](case_management/index.md)** — Case types, stages, and team assignments
+- **[CEL expressions](cel/index.md)** — Common Expression Language for rules and formulas
+- **[Change request types](change_request_types/index.md)** — Configuring change request workflows (NEW V2)
+- **[Consent configuration](consent/index.md)** — Managing data sharing consent (NEW V2)
+- **[Custom fields](custom_fields/index.md)** — Registrant field groups
+- **[Document management](document_management/index.md)** — Document directories, categories, and retention
+- **[DRIMS configuration](drims/index.md)** — Disaster-responsive and shock-responsive settings
+- **[Eligibility rules](eligibility/index.md)** — Configuring who qualifies for programs
+- **[Entitlement formulas](entitlement_formulas/index.md)** — Calculating benefit amounts
+- **[Event data](event_data/index.md)** — Capturing external data from surveys and forms (V2 enhanced)
+- **[Farmer registry](farmer_registry/index.md)** — Farm entity configuration
+- **[GIS configuration](gis/index.md)** — Spatial data layers, color schemes, and map reports
+- **[Graduation](graduation/index.md)** — Exit pathways and criteria for program beneficiaries
+- **[Grievance redress](grievance_redress/index.md)** — Ticket categories, service-level rules, teams, and tags
+- **[Hazard management](hazard_management/index.md)** — Hazard categories, incidents, and program linking
+- **[Import matching](import_matching/index.md)** — Deduplication during import
+- **[OpenSPP Studio](studio/index.md)** — No-code configuration tool (NEW V2)
+- **[Role configuration](role_configuration/index.md)** — Configuring users, roles, and role-based access (global and local roles)
+- **[Scoring & assessment](scoring/index.md)** — Scoring models and dimensions for targeting
+- **[Service points](service_points/index.md)** — Service delivery location configuration
+- **[Session tracking](session_tracking/index.md)** — Session types and attendance tracking
+- **[Simulation](simulation/index.md)** — Scenario modeling for program planning
+- **[Storage backend](storage_backend/index.md)** — File storage backends (local disk, cloud object stores)
+- **[Variables and indicators](variables/index.md)** — Unified variable system (NEW V2)
+- **[Vocabulary system](vocabulary/index.md)** — Standardized codes and terminologies (NEW V2)
 
 ```{toctree}
 :maxdepth: 2
 :hidden:
 
-studio/index
+alerts/index
+approval_workflows/index
+area_management/index
+audit/index
+banking/index
+case_management/index
 cel/index
-eligibility/index
-entitlement_formulas/index
-vocabulary/index
-variables/index
-event_data/index
 change_request_types/index
 consent/index
-role_configuration/index
 custom_fields/index
-import_matching/index
+document_management/index
+drims/index
+eligibility/index
+entitlement_formulas/index
+event_data/index
 farmer_registry/index
+gis/index
+graduation/index
+grievance_redress/index
+hazard_management/index
+import_matching/index
+studio/index
+role_configuration/index
+scoring/index
+service_points/index
+session_tracking/index
+simulation/index
+storage_backend/index
+variables/index
+vocabulary/index
 ```
-
-<!-- Hidden until ready: drims/index -->

--- a/docs/config_guide/role_configuration/overview.md
+++ b/docs/config_guide/role_configuration/overview.md
@@ -103,4 +103,4 @@ When roles are active, changes made directly in the user's "Access Rights" tab a
 
 - {doc}`assigning_roles` - Step-by-step role assignment
 - {doc}`predefined_roles` - List of default roles
-- {doc}`/tutorial/user_guides/administrating_role_based_access` - Illustrated tutorial
+- {doc}`/user_guide/getting_started/administrating_role_based_access` - Illustrated tutorial

--- a/docs/config_guide/role_configuration/troubleshooting.md
+++ b/docs/config_guide/role_configuration/troubleshooting.md
@@ -176,4 +176,4 @@ If issues persist after checking this guide:
 
 - {doc}`overview` - Understanding how access control works
 - {doc}`assigning_roles` - Correct role assignment procedures
-- {doc}`/tutorial/user_guides/administrating_role_based_access` - Illustrated tutorial
+- {doc}`/user_guide/getting_started/administrating_role_based_access` - Illustrated tutorial

--- a/docs/config_guide/variables/creating_variables.md
+++ b/docs/config_guide/variables/creating_variables.md
@@ -316,7 +316,7 @@ Edit a variable and set the **Category** field.
 
 **Can't find Source Field in dropdown?**
 
-The Source Model must be set first. If the field still doesn't appear, it may not be accessible via the ORM.
+The Source Model must be set first. If the field still doesn't appear, it may be a computed field that OpenSPP cannot use as a variable source — ask your administrator.
 
 **Aggregate Filter not working?**
 


### PR DESCRIPTION
## Why is this change needed?

Final QA pass for ticket #831 — cross-cutting quality review after all 9 config guide topic PRs (#822–#830) merged.

## How was the change implemented?

**Main `config_guide/index.md`**
- Added all 30 topics (was only 13) to the bullet list and toctree
- Sorted alphabetically per the acceptance criteria
- Un-hid DRIMS (docs were merged in #135)

**Jargon / Odoo identifiers removed from prose**
- `consent/api_consent_filtering.md` — "O(1) consent checks" → plain-English explanation
- `change_request_types/overview.md` — "real Odoo fields, not JSON" → "structured, queryable fields"
- `drims/index.md` — "3PL", "OCHA HDX", "4W reports" expanded
- `cel/syntax.md` — "No ORM access" → "Cannot read records directly from the database"
- `variables/creating_variables.md` — "accessible via the ORM" → plain-English hint

**Broken `{doc}` cross-references fixed**
- `role_configuration/overview.md` — `/tutorial/user_guides/administrating_role_based_access` → `/user_guide/getting_started/administrating_role_based_access`
- `role_configuration/troubleshooting.md` — same fix

## New unit tests

N/A — documentation-only change.

## Unit tests executed by the author

Sphinx build: `make html` — **298 warnings**, down from the 301 baseline. No new warnings introduced.

## How to test manually

1. `make html` in the documentation repo
2. Confirm warning count is ≤ 301 (baseline)
3. Open `_build/html/config_guide/index.html` — all 30 topics listed, alphabetically ordered, every link resolves
4. Visit `role_configuration/overview.html` and `troubleshooting.html` — "Illustrated tutorial" link now resolves

## Related links

- OpenProject ticket: https://projects.acn.fr/projects/acn-eng/work_packages/831